### PR TITLE
Remove image difference detection due to it causes coredump.

### DIFF
--- a/src/socket_publisher/data_serializer.cc
+++ b/src/socket_publisher/data_serializer.cc
@@ -66,18 +66,12 @@ std::string data_serializer::serialize_map_diff() {
 std::string data_serializer::serialize_latest_frame(const unsigned int image_quality) {
 
     const auto image = frame_publisher_->draw_frame();
-    const auto image_hash = get_frame_hash(image);
-    if (image_hash != frame_hash_) {
-        frame_hash_ = image_hash;
-
-        std::vector<uchar> buf;
-        const std::vector<int> params{static_cast<int>(cv::IMWRITE_JPEG_QUALITY), static_cast<int>(image_quality)};
-        cv::imencode(".jpg", image, buf, params);
-        const auto char_buf = reinterpret_cast<const unsigned char*>(buf.data());
-        const std::string base64_serial = base64_encode(char_buf, buf.size());
-        return base64_serial;
-    }
-    return "";
+    std::vector<uchar> buf;
+    const std::vector<int> params{static_cast<int>(cv::IMWRITE_JPEG_QUALITY), static_cast<int>(image_quality)};
+    cv::imencode(".jpg", image, buf, params);
+    const auto char_buf = reinterpret_cast<const unsigned char*>(buf.data());
+    const std::string base64_serial = base64_encode(char_buf, buf.size());
+    return base64_serial;
 }
 
 std::string data_serializer::serialize_as_protobuf(const std::vector<openvslam::data::keyframe*>& keyfrms,

--- a/src/socket_publisher/data_serializer.h
+++ b/src/socket_publisher/data_serializer.h
@@ -60,25 +60,6 @@ private:
         return pose(0, 3) + pose(1, 3) + pose(2, 3);
     }
 
-    inline int get_frame_hash(const cv::Mat& frame) {
-        const auto n_channel = frame.channels();
-
-        if (n_channel == 1) {
-            return frame.at<uchar>(image_height_ * 0.5, image_width_ * 0.25)
-                   + frame.at<uchar>(image_height_ * 0.5, image_width_ * 0.5)
-                   + frame.at<uchar>(image_height_ * 0.5, image_width_ * 0.75);
-        }
-        else {
-            return rgb_to_24bit(frame.at<cv::Vec3b>(image_height_ * 0.5, image_width_ * 0.25))
-                   + rgb_to_24bit(frame.at<cv::Vec3b>(image_height_ * 0.5, image_width_ * 0.5))
-                   + rgb_to_24bit(frame.at<cv::Vec3b>(image_height_ * 0.5, image_width_ * 0.75));
-        }
-    }
-
-    inline int rgb_to_24bit(const cv::Vec3b& rgb) {
-        return rgb[0] * 0x1000 + rgb[0] * 0x10 + rgb[0];
-    }
-
     std::string serialize_as_protobuf(const std::vector<openvslam::data::keyframe*>& keyfrms,
                                       const std::vector<openvslam::data::landmark*>& all_landmarks,
                                       const std::set<openvslam::data::landmark*>& local_landmarks,


### PR DESCRIPTION
Difference detection of cv::Mat causes core dump.
Therefore, I disabled it.
Now, the frame image communication frequency is limited by `Socket.emitting_interval` on setting file.