### PR TITLE
Add a shorthand command for --map-db

### DIFF
--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -295,7 +295,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -295,7 +295,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_image_localization.cc
+++ b/example/run_image_localization.cc
@@ -145,7 +145,7 @@ int main(int argc, char* argv[]) {
     auto vocab_file_path = op.add<popl::Value<std::string>>("v", "vocab", "vocabulary file path");
     auto img_dir_path = op.add<popl::Value<std::string>>("i", "img-dir", "directory path which contains images");
     auto setting_file_path = op.add<popl::Value<std::string>>("s", "setting", "setting file path");
-    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "path to a prebuilt map database");
+    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "path to a prebuilt map database");
     auto mapping = op.add<popl::Switch>("", "mapping", "perform mapping as well as localization");
     auto mask_img_path = op.add<popl::Value<std::string>>("", "mask", "mask image path", "");
     auto frame_skip = op.add<popl::Value<unsigned int>>("", "frame-skip", "interval of frame skip", 1);

--- a/example/run_image_slam.cc
+++ b/example/run_image_slam.cc
@@ -159,7 +159,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_image_slam.cc
+++ b/example/run_image_slam.cc
@@ -159,7 +159,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_kitti_slam.cc
+++ b/example/run_kitti_slam.cc
@@ -268,7 +268,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_kitti_slam.cc
+++ b/example/run_kitti_slam.cc
@@ -268,7 +268,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_tum_slam.cc
+++ b/example/run_tum_slam.cc
@@ -258,7 +258,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_tum_slam.cc
+++ b/example/run_tum_slam.cc
@@ -258,7 +258,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_video_localization.cc
+++ b/example/run_video_localization.cc
@@ -144,7 +144,7 @@ int main(int argc, char* argv[]) {
     auto vocab_file_path = op.add<popl::Value<std::string>>("v", "vocab", "vocabulary file path");
     auto video_file_path = op.add<popl::Value<std::string>>("m", "video", "video file path");
     auto setting_file_path = op.add<popl::Value<std::string>>("s", "setting", "setting file path");
-    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "path to a prebuilt map database");
+    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "path to a prebuilt map database");
     auto mapping = op.add<popl::Switch>("", "mapping", "perform mapping as well as localization");
     auto mask_img_path = op.add<popl::Value<std::string>>("", "mask", "mask image path", "");
     auto frame_skip = op.add<popl::Value<unsigned int>>("", "frame-skip", "interval of frame skip", 1);

--- a/example/run_video_slam.cc
+++ b/example/run_video_slam.cc
@@ -160,7 +160,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }

--- a/example/run_video_slam.cc
+++ b/example/run_video_slam.cc
@@ -160,7 +160,7 @@ int main(int argc, char* argv[]) {
     auto auto_term = op.add<popl::Switch>("", "auto-term", "automatically terminate the viewer");
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
-    auto map_db_path = op.add<popl::Value<std::string>>("d", "map-db", "store a map database at this path after SLAM", "");
+    auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after SLAM", "");
     try {
         op.parse(argc, argv);
     }


### PR DESCRIPTION
Thank you for your great work!

On example code, shorthand command of "--map-db" are different between "**-slam.cc" and "**-localization.cc".
I think so better to be same shorthand command.