### PR TITLE
Fix example document on EuRoC session

### DIFF
--- a/docs/example.rst
+++ b/docs/example.rst
@@ -224,12 +224,12 @@ If you have built examples with Pangolin Viewer support, a map viewer and frame 
     run_euroc_slam
     ...
     # monocular SLAM with any EuRoC sequence
-    $ ./run_kitti_slam \
+    $ ./run_euroc_slam \
         -v /path/to/orb_vocab/orb_vocab.dbow2 \
         -d /path/to/EuRoC/MAV/mav0/ \
         -s ../example/euroc/EuRoC_mono.yaml
     # stereo SLAM with any EuRoC sequence
-    $ ./run_kitti_slam \
+    $ ./run_euroc_slam \
         -v /path/to/orb_vocab/orb_vocab.dbow2 \
         -d /path/to/EuRoC/MAV/mav0/ \
         -s ../example/euroc/EuRoC_stereo.yaml


### PR DESCRIPTION
on EuRoC session in example document, 
It is written `run_kitti_slam`, but I think `run_euroc_slam` is correct.

Thanks.