### PR TITLE
fix the order of build argument

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -35,7 +35,7 @@ Execute the following commands:
     .. code-block:: bash
 
         # building the docker image with four threads
-        docker build -t --build-arg NUM_THREADS=4 openvslam-desktop .
+        docker build -t  openvslam-desktop . --build-arg NUM_THREADS=4
 
 
 .. _section-start-docker-container:


### PR DESCRIPTION
fix the order of argument: NUM_THREADS
from 
`docker build -t --build-arg NUM_THREADS=4 openvslam-desktop .`

to 
`docker build -t  openvslam-desktop .  --build-arg NUM_THREADS=4`