### PR TITLE
Avoid SEGV when keypoints are detected near edges of images

### DIFF
--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -294,10 +294,8 @@ void orb_extractor::compute_fast_keypoints(std::vector<std::vector<cv::KeyPoint>
         const unsigned int width = max_border_x - min_border_x;
         const unsigned int height = max_border_y - min_border_y;
 
-        const unsigned int num_cols = width / cell_size;
-        const unsigned int num_rows = height / cell_size;
-        const unsigned int cell_width = std::ceil(width / num_cols);
-        const unsigned int cell_height = std::ceil(height / num_rows);
+        const unsigned int num_cols = std::ceil(width / cell_size) + 1;
+        const unsigned int num_rows = std::ceil(height / cell_size) + 1;
 
         std::vector<cv::KeyPoint> keypts_to_distribute;
         keypts_to_distribute.reserve(orb_params_.max_num_keypts_ * 10);
@@ -306,11 +304,11 @@ void orb_extractor::compute_fast_keypoints(std::vector<std::vector<cv::KeyPoint>
 #pragma omp parallel for
 #endif
         for (unsigned int i = 0; i < num_rows; ++i) {
-            const unsigned int min_y = min_border_y + i * cell_height;
+            const unsigned int min_y = min_border_y + i * cell_size;
             if (max_border_y - overlap <= min_y) {
                 continue;
             }
-            unsigned int max_y = min_y + cell_height + overlap;
+            unsigned int max_y = min_y + cell_size + overlap;
             if (max_border_y < max_y) {
                 max_y = max_border_y;
             }
@@ -319,11 +317,11 @@ void orb_extractor::compute_fast_keypoints(std::vector<std::vector<cv::KeyPoint>
 #pragma omp parallel for
 #endif
             for (unsigned int j = 0; j < num_cols; ++j) {
-                const unsigned int min_x = min_border_x + j * cell_width;
+                const unsigned int min_x = min_border_x + j * cell_size;
                 if (max_border_x - overlap <= min_x) {
                     continue;
                 }
-                unsigned int max_x = min_x + cell_width + overlap;
+                unsigned int max_x = min_x + cell_size + overlap;
                 if (max_border_x < max_x) {
                     max_x = max_border_x;
                 }
@@ -356,8 +354,8 @@ void orb_extractor::compute_fast_keypoints(std::vector<std::vector<cv::KeyPoint>
 #endif
                 {
                     for (auto& keypt : keypts_in_cell) {
-                        keypt.pt.x += j * cell_width;
-                        keypt.pt.y += i * cell_height;
+                        keypt.pt.x += j * cell_size;
+                        keypt.pt.y += i * cell_size;
                         // mask内かどうかを確認
                         if (!mask.empty() && is_in_mask(min_border_y + keypt.pt.y, min_border_x + keypt.pt.x, scale_factor)) {
                             continue;

--- a/src/openvslam/feature/orb_extractor.h
+++ b/src/openvslam/feature/orb_extractor.h
@@ -12,9 +12,10 @@ namespace feature {
 
 class orb_extractor {
 public:
+    orb_extractor() = delete;
+
     orb_extractor(const unsigned int max_num_keypts, const float scale_factor, const unsigned int num_levels,
                   const unsigned int ini_fast_thr, const unsigned int min_fast_thr,
-                  const unsigned int edge_thr = 19, const unsigned int patch_size = 31,
                   const std::vector<std::vector<float>>& mask_rects = {});
 
     explicit orb_extractor(const orb_params& orb_params);
@@ -122,6 +123,14 @@ private:
 
     //! parameters for ORB extraction
     orb_params orb_params_;
+
+    //! BRIEF orientation
+    static constexpr unsigned int fast_patch_size_ = 31;
+    //! half size of FAST patch
+    static constexpr int fast_half_patch_size_ = fast_patch_size_ / 2;
+
+    //! size of maximum ORB patch radius
+    static constexpr unsigned int orb_patch_radius_ = 19;
 
     //! rectangle mask has been already initialized or not
     bool mask_is_initialized_ = false;

--- a/src/openvslam/feature/orb_params.cc
+++ b/src/openvslam/feature/orb_params.cc
@@ -5,15 +5,11 @@
 namespace openvslam {
 namespace feature {
 
-orb_params::orb_params() : half_patch_size_(patch_size_ / 2) {}
-
 orb_params::orb_params(const unsigned int max_num_keypts, const float scale_factor, const unsigned int num_levels,
                        const unsigned int ini_fast_thr, const unsigned int min_fast_thr,
-                       const unsigned int edge_thr, const unsigned int patch_size,
                        const std::vector<std::vector<float>>& mask_rects)
         : max_num_keypts_(max_num_keypts), scale_factor_(scale_factor), num_levels_(num_levels),
           ini_fast_thr_(ini_fast_thr), min_fast_thr(min_fast_thr),
-          edge_thr_(edge_thr), patch_size_(patch_size), half_patch_size_(patch_size_ / 2),
           mask_rects_(mask_rects) {
     for (const auto& v : mask_rects_) {
         if (v.size() != 4) {
@@ -34,8 +30,6 @@ orb_params::orb_params(const YAML::Node& yaml_node)
                      yaml_node["Feature.num_levels"].as<unsigned int>(8),
                      yaml_node["Feature.ini_fast_threshold"].as<unsigned int>(20),
                      yaml_node["Feature.min_fast_threshold"].as<unsigned int>(7),
-                     yaml_node["Feature.edge_threshold"].as<unsigned int>(19),
-                     yaml_node["Feature.patch_size"].as<unsigned int>(31),
                      yaml_node["Feature.mask_rectangles"].as<std::vector<std::vector<float>>>(std::vector<std::vector<float>>())) {}
 
 void orb_params::show_parameters() const {
@@ -44,9 +38,6 @@ void orb_params::show_parameters() const {
     std::cout << "- number of levels: " << num_levels_ << std::endl;
     std::cout << "- initial fast threshold: " << ini_fast_thr_ << std::endl;
     std::cout << "- minimum fast threshold: " << min_fast_thr << std::endl;
-    std::cout << "- edge threshold: " << edge_thr_ << std::endl;
-    std::cout << "- patch size: " << patch_size_ << std::endl;
-    std::cout << "- half patch size: " << half_patch_size_ << std::endl;
     if (!mask_rects_.empty()) {
         std::cout << "- mask rectangles:" << std::endl;
         for (const auto& mask_rect : mask_rects_) {

--- a/src/openvslam/feature/orb_params.h
+++ b/src/openvslam/feature/orb_params.h
@@ -7,11 +7,10 @@ namespace openvslam {
 namespace feature {
 
 struct orb_params {
-    orb_params();
+    orb_params() = default;
 
     orb_params(const unsigned int max_num_keypts, const float scale_factor, const unsigned int num_levels,
                const unsigned int ini_fast_thr, const unsigned int min_fast_thr,
-               const unsigned int edge_thr = 19, const unsigned int patch_size = 31,
                const std::vector<std::vector<float>>& mask_rects = {});
 
     explicit orb_params(const YAML::Node& yaml_node);
@@ -25,9 +24,6 @@ struct orb_params {
     unsigned int num_levels_ = 8;
     unsigned int ini_fast_thr_ = 20;
     unsigned int min_fast_thr = 7;
-    unsigned int edge_thr_ = 19;
-    unsigned int patch_size_ = 31;
-    int half_patch_size_;
 
     //! mask領域を表す特徴点領域のvector
     //! 各領域は[x_min / cols, x_max / cols, y_min / rows, y_max / rows]で表現

--- a/test/openvslam/feature/orb_params.cc
+++ b/test/openvslam/feature/orb_params.cc
@@ -12,9 +12,7 @@ TEST(orb_params, load_yaml_without_rectangle_mask) {
             "Feature.scale_factor: 1.3\n"
             "Feature.num_levels: 12\n"
             "Feature.ini_fast_threshold: 25\n"
-            "Feature.min_fast_threshold: 9\n"
-            "Feature.edge_threshold: 15\n"
-            "Feature.patch_size: 21\n";
+            "Feature.min_fast_threshold: 9\n";
 
     const auto yaml_node = YAML::Load(yaml);
     const auto params = feature::orb_params(yaml_node);
@@ -24,8 +22,6 @@ TEST(orb_params, load_yaml_without_rectangle_mask) {
     EXPECT_EQ(params.num_levels_, 12);
     EXPECT_EQ(params.ini_fast_thr_, 25);
     EXPECT_EQ(params.min_fast_thr, 9);
-    EXPECT_EQ(params.edge_thr_, 15);
-    EXPECT_EQ(params.patch_size_, 21);
     EXPECT_EQ(params.mask_rects_.size(), 0);
 }
 
@@ -38,8 +34,6 @@ TEST(orb_params, load_yaml_with_rectangle_mask) {
             "Feature.num_levels: 12\n"
             "Feature.ini_fast_threshold: 25\n"
             "Feature.min_fast_threshold: 9\n"
-            "Feature.edge_threshold: 15\n"
-            "Feature.patch_size: 21\n"
             "Feature.mask_rectangles:\n"
             "- [0.2, 0.5, 0.3, 0.8]\n"
             "- [0.28, 0.59, 0.1, 0.2]\n";
@@ -52,8 +46,6 @@ TEST(orb_params, load_yaml_with_rectangle_mask) {
     EXPECT_EQ(params.num_levels_, 12);
     EXPECT_EQ(params.ini_fast_thr_, 25);
     EXPECT_EQ(params.min_fast_thr, 9);
-    EXPECT_EQ(params.edge_thr_, 15);
-    EXPECT_EQ(params.patch_size_, 21);
     EXPECT_EQ(params.mask_rects_.size(), 2);
 
     EXPECT_FLOAT_EQ(params.mask_rects_.at(0).at(0), 0.2);
@@ -77,8 +69,6 @@ TEST(orb_params, load_yaml_with_rectangle_mask_exception_1) {
             "Feature.num_levels: 12\n"
             "Feature.ini_fast_threshold: 25\n"
             "Feature.min_fast_threshold: 9\n"
-            "Feature.edge_threshold: 15\n"
-            "Feature.patch_size: 21\n"
             "Feature.mask_rectangles:\n"
             "- [0.2, 0.5, 0.3, 0.8]\n"
             "- [0.28, 0.59, 0.1]\n";
@@ -97,8 +87,6 @@ TEST(orb_params, load_yaml_with_rectangle_mask_exception_2) {
             "Feature.num_levels: 12\n"
             "Feature.ini_fast_threshold: 25\n"
             "Feature.min_fast_threshold: 9\n"
-            "Feature.edge_threshold: 15\n"
-            "Feature.patch_size: 21\n"
             "Feature.mask_rectangles:\n"
             "- [0.2, 0.5, 0.3, 0.8]\n"
             "- [0.28, 0.28, 0.1, 0.2]\n";
@@ -117,8 +105,6 @@ TEST(orb_params, load_yaml_with_rectangle_mask_exception_3) {
             "Feature.num_levels: 12\n"
             "Feature.ini_fast_threshold: 25\n"
             "Feature.min_fast_threshold: 9\n"
-            "Feature.edge_threshold: 15\n"
-            "Feature.patch_size: 21\n"
             "Feature.mask_rectangles:\n"
             "- [0.2, 0.5, 0.3, 0.8]\n"
             "- [0.25, 0.21, 0.1, 0.2]\n";
@@ -137,8 +123,6 @@ TEST(orb_params, load_yaml_with_rectangle_mask_exception_4) {
             "Feature.num_levels: 12\n"
             "Feature.ini_fast_threshold: 25\n"
             "Feature.min_fast_threshold: 9\n"
-            "Feature.edge_threshold: 15\n"
-            "Feature.patch_size: 21\n"
             "Feature.mask_rectangles:\n"
             "- [0.2, 0.5, 0.3, 0.8]\n"
             "- [0.28, 0.59, 0.8, 0.8]\n";
@@ -157,8 +141,6 @@ TEST(orb_params, load_yaml_with_rectangle_mask_exception_5) {
             "Feature.num_levels: 12\n"
             "Feature.ini_fast_threshold: 25\n"
             "Feature.min_fast_threshold: 9\n"
-            "Feature.edge_threshold: 15\n"
-            "Feature.patch_size: 21\n"
             "Feature.mask_rectangles:\n"
             "- [0.2, 0.5, 0.3, 0.8]\n"
             "- [0.28, 0.59, 0.7, 0.2]\n";


### PR DESCRIPTION
close #44

- Fixed the two parameters: `Feature.edge_threshold` and `Feature.patch_size`
- Disabled padding of scaled images because it might cause SEGV in outside of ROI