### PR TITLE
Refactoring of the utilities for the examples

### DIFF
--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -32,7 +32,7 @@ void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
                    const std::string& vocab_file_path, const std::string& sequence_dir_path,
                    const unsigned int frame_skip, const bool no_sleep, const bool auto_term,
                    const bool eval_log, const std::string& map_db_path) {
-    euroc_mono_sequence sequence(sequence_dir_path);
+    const euroc_sequence sequence(sequence_dir_path);
     const auto frames = sequence.get_frames();
 
     // build a SLAM system
@@ -55,7 +55,7 @@ void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
     std::thread thread([&]() {
         for (unsigned int i = 0; i < frames.size(); ++i) {
             const auto& frame = frames.at(i);
-            const auto img = cv::imread(frame.img_path_, cv::IMREAD_UNCHANGED);
+            const auto img = cv::imread(frame.left_img_path_, cv::IMREAD_UNCHANGED);
 
             const auto tp_1 = std::chrono::steady_clock::now();
 
@@ -143,7 +143,7 @@ void stereo_tracking(const std::shared_ptr<openvslam::config>& cfg,
                      const std::string& vocab_file_path, const std::string& sequence_dir_path,
                      const unsigned int frame_skip, const bool no_sleep, const bool auto_term,
                      const bool eval_log, const std::string& map_db_path) {
-    euroc_stereo_sequence sequence(sequence_dir_path);
+    const euroc_sequence sequence(sequence_dir_path);
     const auto frames = sequence.get_frames();
 
     // variables for stereo image rectification

--- a/example/run_image_localization.cc
+++ b/example/run_image_localization.cc
@@ -32,8 +32,8 @@ void mono_localization(const std::shared_ptr<openvslam::config>& cfg,
     // load the mask image
     const cv::Mat mask = mask_img_path.empty() ? cv::Mat{} : cv::imread(mask_img_path, cv::IMREAD_GRAYSCALE);
 
-    image_sequence sequence(image_dir_path);
-    const auto img_paths = sequence.get_image_paths();
+    const image_sequence sequence(image_dir_path, cfg->camera_->fps_);
+    const auto frames = sequence.get_frames();
 
     // build a SLAM system
     openvslam::system SLAM(cfg, vocab_file_path);
@@ -58,21 +58,19 @@ void mono_localization(const std::shared_ptr<openvslam::config>& cfg,
 #endif
 
     std::vector<double> track_times;
-    track_times.reserve(img_paths.size());
-
-    double timestamp = 0.0;
+    track_times.reserve(frames.size());
 
     // run the SLAM in another thread
     std::thread thread([&]() {
-        for (unsigned int i = 0; i < img_paths.size(); ++i) {
-            const auto& img_path = img_paths.at(i);
-            const auto img = cv::imread(img_path, cv::IMREAD_UNCHANGED);
+        for (unsigned int i = 0; i < frames.size(); ++i) {
+            const auto& frame = frames.at(i);
+            const auto img = cv::imread(frame.img_path_, cv::IMREAD_UNCHANGED);
 
             const auto tp_1 = std::chrono::steady_clock::now();
 
             if (!img.empty() && (i % frame_skip == 0)) {
                 // input the current frame and estimate the camera pose
-                SLAM.track_for_monocular(img, timestamp, mask);
+                SLAM.track_for_monocular(img, frame.timestamp_, mask);
             }
 
             const auto tp_2 = std::chrono::steady_clock::now();
@@ -83,14 +81,12 @@ void mono_localization(const std::shared_ptr<openvslam::config>& cfg,
             }
 
             // wait until the timestamp of the next frame
-            if (!no_sleep) {
-                const auto wait_time = 1.0 / cfg->camera_->fps_ - track_time;
+            if (!no_sleep && i < frames.size() - 1) {
+                const auto wait_time = frames.at(i + 1).timestamp_ - (frame.timestamp_ + track_time);
                 if (0.0 < wait_time) {
                     std::this_thread::sleep_for(std::chrono::microseconds(static_cast<unsigned int>(wait_time * 1e6)));
                 }
             }
-
-            timestamp += 1.0 / cfg->camera_->fps_;
 
             // check if the termination of SLAM system is requested or not
             if (SLAM.terminate_is_requested()) {

--- a/example/run_kitti_slam.cc
+++ b/example/run_kitti_slam.cc
@@ -32,7 +32,7 @@ void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
                    const std::string& vocab_file_path, const std::string& sequence_dir_path,
                    const unsigned int frame_skip, const bool no_sleep, const bool auto_term,
                    const bool eval_log, const std::string& map_db_path) {
-    kitti_mono_sequence sequence(sequence_dir_path);
+    const kitti_sequence sequence(sequence_dir_path);
     const auto frames = sequence.get_frames();
 
     // build a SLAM system
@@ -55,7 +55,7 @@ void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
     std::thread thread([&]() {
         for (unsigned int i = 0; i < frames.size(); ++i) {
             const auto& frame = frames.at(i);
-            const auto img = cv::imread(frame.img_path_, cv::IMREAD_UNCHANGED);
+            const auto img = cv::imread(frame.left_img_path_, cv::IMREAD_UNCHANGED);
 
             const auto tp_1 = std::chrono::steady_clock::now();
 
@@ -143,7 +143,7 @@ void stereo_tracking(const std::shared_ptr<openvslam::config>& cfg,
                      const std::string& vocab_file_path, const std::string& sequence_dir_path,
                      const unsigned int frame_skip, const bool no_sleep, const bool auto_term,
                      const bool eval_log, const std::string& map_db_path) {
-    kitti_stereo_sequence sequence(sequence_dir_path);
+    const kitti_sequence sequence(sequence_dir_path);
     const auto frames = sequence.get_frames();
 
     // build a SLAM system

--- a/example/util/euroc_util.cc
+++ b/example/util/euroc_util.cc
@@ -6,48 +6,7 @@
 #include <cassert>
 #include <algorithm>
 
-euroc_mono_sequence::euroc_mono_sequence(const std::string& seq_dir_path) {
-    const std::string timestamp_file_path = seq_dir_path + "/cam0/data.csv";
-    const std::string img_dir_path = seq_dir_path + "/cam0/data/";
-
-    timestamps_.clear();
-    img_file_paths_.clear();
-
-    // load timestamps
-    std::ifstream ifs_timestamp;
-    ifs_timestamp.open(timestamp_file_path.c_str());
-
-    // load header row
-    std::string s;
-    getline(ifs_timestamp, s);
-
-    while (!ifs_timestamp.eof()) {
-        getline(ifs_timestamp, s);
-        std::replace(s.begin(), s.end(), ',', ' ');
-        if (!s.empty()) {
-            std::stringstream ss;
-            ss << s;
-            unsigned long long timestamp;
-            ss >> timestamp;
-            timestamps_.push_back(timestamp / static_cast<double>(1E9));
-            img_file_paths_.push_back(img_dir_path + std::to_string(timestamp) + ".png");
-        }
-    }
-
-    ifs_timestamp.close();
-
-    num_imgs_ = timestamps_.size();
-}
-
-std::vector<euroc_mono_sequence::frame> euroc_mono_sequence::get_frames() const {
-    std::vector<frame> frames;
-    for (unsigned int i = 0; i < num_imgs_; ++i) {
-        frames.emplace_back(frame{img_file_paths_.at(i), timestamps_.at(i)});
-    }
-    return frames;
-}
-
-euroc_stereo_sequence::euroc_stereo_sequence(const std::string& seq_dir_path) {
+euroc_sequence::euroc_sequence(const std::string& seq_dir_path) {
     const std::string timestamp_file_path = seq_dir_path + "/cam0/data.csv";
     const std::string left_img_dir_path = seq_dir_path + "/cam0/data/";
     const std::string right_img_dir_path = seq_dir_path + "/cam1/data/";
@@ -59,6 +18,9 @@ euroc_stereo_sequence::euroc_stereo_sequence(const std::string& seq_dir_path) {
     // load timestamps
     std::ifstream ifs_timestamp;
     ifs_timestamp.open(timestamp_file_path.c_str());
+    if (!ifs_timestamp) {
+        throw std::runtime_error("Could not load a timestamp file from " + timestamp_file_path);
+    }
 
     // load header row
     std::string s;
@@ -79,13 +41,14 @@ euroc_stereo_sequence::euroc_stereo_sequence(const std::string& seq_dir_path) {
     }
 
     ifs_timestamp.close();
-
-    num_imgs_ = timestamps_.size();
 }
 
-std::vector<euroc_stereo_sequence::frame> euroc_stereo_sequence::get_frames() const {
+std::vector<euroc_sequence::frame> euroc_sequence::get_frames() const {
     std::vector<frame> frames;
-    for (unsigned int i = 0; i < num_imgs_; ++i) {
+    assert(timestamps_.size() == left_img_file_paths_.size());
+    assert(timestamps_.size() == right_img_file_paths_.size());
+    assert(left_img_file_paths_.size() == right_img_file_paths_.size());
+    for (unsigned int i = 0; i < timestamps_.size(); ++i) {
         frames.emplace_back(frame{left_img_file_paths_.at(i), right_img_file_paths_.at(i), timestamps_.at(i)});
     }
     return frames;

--- a/example/util/euroc_util.h
+++ b/example/util/euroc_util.h
@@ -1,32 +1,10 @@
-#ifndef EUROC_UTIL_H
-#define EUROC_UTIL_H
+#ifndef EXAMPLE_UTIL_EUROC_UTIL_H
+#define EXAMPLE_UTIL_EUROC_UTIL_H
 
 #include <string>
 #include <vector>
 
-class euroc_mono_sequence {
-public:
-    struct frame {
-        frame(const std::string& img_path, const double timestamp)
-                : img_path_(img_path), timestamp_(timestamp) {};
-
-        const std::string img_path_;
-        const double timestamp_;
-    };
-
-    explicit euroc_mono_sequence(const std::string& seq_dir_path);
-
-    virtual ~euroc_mono_sequence() = default;
-
-    std::vector<frame> get_frames() const;
-
-private:
-    std::vector<double> timestamps_;
-    std::vector<std::string> img_file_paths_;
-    unsigned int num_imgs_;
-};
-
-class euroc_stereo_sequence {
+class euroc_sequence {
 public:
     struct frame {
         frame(const std::string& left_img_path, const std::string& right_img_path, const double timestamp)
@@ -37,9 +15,9 @@ public:
         const double timestamp_;
     };
 
-    explicit euroc_stereo_sequence(const std::string& seq_dir_path);
+    explicit euroc_sequence(const std::string& seq_dir_path);
 
-    virtual ~euroc_stereo_sequence() = default;
+    virtual ~euroc_sequence() = default;
 
     std::vector<frame> get_frames() const;
 
@@ -47,7 +25,6 @@ private:
     std::vector<double> timestamps_;
     std::vector<std::string> left_img_file_paths_;
     std::vector<std::string> right_img_file_paths_;
-    unsigned int num_imgs_;
 };
 
-#endif // EUROC_UTIL_H
+#endif // EXAMPLE_UTIL_EUROC_UTIL_H

--- a/example/util/image_util.cc
+++ b/example/util/image_util.cc
@@ -3,20 +3,24 @@
 #include <dirent.h>
 #include <algorithm>
 
-image_sequence::image_sequence(const std::string& img_dir_path) {
+image_sequence::image_sequence(const std::string& img_dir_path, const double fps) : fps_(fps) {
     DIR* dir;
     if ((dir = opendir(img_dir_path.c_str())) == nullptr) {
 
     }
     dirent* dp;
     for (dp = readdir(dir); dp != nullptr; dp = readdir(dir)) {
-        img_paths_.push_back(img_dir_path + "/" + std::string(dp->d_name));
+        img_file_paths_.push_back(img_dir_path + "/" + std::string(dp->d_name));
     }
     closedir(dir);
 
-    std::sort(img_paths_.begin(), img_paths_.end());
+    std::sort(img_file_paths_.begin(), img_file_paths_.end());
 }
 
-std::vector<std::string> image_sequence::get_image_paths() const {
-    return img_paths_;
+std::vector<image_sequence::frame> image_sequence::get_frames() const {
+    std::vector<frame> frames;
+    for (unsigned int i = 0; i < img_file_paths_.size(); ++i) {
+        frames.emplace_back(frame{img_file_paths_.at(i), (1.0 / fps_) * i});
+    }
+    return frames;
 }

--- a/example/util/image_util.cc
+++ b/example/util/image_util.cc
@@ -2,15 +2,20 @@
 
 #include <dirent.h>
 #include <algorithm>
+#include <stdexcept>
 
 image_sequence::image_sequence(const std::string& img_dir_path, const double fps) : fps_(fps) {
     DIR* dir;
     if ((dir = opendir(img_dir_path.c_str())) == nullptr) {
-
+        throw std::runtime_error("directory " + img_dir_path + " does not exist");
     }
     dirent* dp;
     for (dp = readdir(dir); dp != nullptr; dp = readdir(dir)) {
-        img_file_paths_.push_back(img_dir_path + "/" + std::string(dp->d_name));
+        const std::string img_file_name = dp->d_name;
+        if (img_file_name == "." || img_file_name == "..") {
+            continue;
+        }
+        img_file_paths_.push_back(img_dir_path + "/" + img_file_name);
     }
     closedir(dir);
 

--- a/example/util/image_util.h
+++ b/example/util/image_util.h
@@ -1,19 +1,29 @@
-#ifndef IMAGE_UTIL_H
-#define IMAGE_UTIL_H
+#ifndef EXAMPLE_UTIL_IMAGE_UTIL_H
+#define EXAMPLE_UTIL_IMAGE_UTIL_H
 
 #include <string>
 #include <vector>
 
 class image_sequence {
 public:
-    explicit image_sequence(const std::string& img_dir_path);
+    struct frame {
+        frame(const std::string& img_path, const double timestamp)
+                : img_path_(img_path), timestamp_(timestamp) {};
+
+        const std::string img_path_;
+        const double timestamp_;
+    };
+
+    image_sequence(const std::string& img_dir_path, const double fps);
 
     virtual ~image_sequence() = default;
 
-    std::vector<std::string> get_image_paths() const;
+    std::vector<frame> get_frames() const;
 
 private:
-    std::vector<std::string> img_paths_;
+    const double fps_;
+
+    std::vector<std::string> img_file_paths_;
 };
 
-#endif // IMAGE_UTIL_H
+#endif // EXAMPLE_UTIL_IMAGE_UTIL_H

--- a/example/util/kitti_util.cc
+++ b/example/util/kitti_util.cc
@@ -5,52 +5,14 @@
 #include <iomanip>
 #include <cassert>
 
-kitti_mono_sequence::kitti_mono_sequence(const std::string& seq_dir_path) {
+kitti_sequence::kitti_sequence(const std::string& seq_dir_path) {
     // load timestamps
     const std::string timestamp_file_path = seq_dir_path + "/times.txt";
     std::ifstream ifs_timestamp;
     ifs_timestamp.open(timestamp_file_path.c_str());
-
-    timestamps_.clear();
-    while (!ifs_timestamp.eof()) {
-        std::string s;
-        getline(ifs_timestamp, s);
-        if (!s.empty()) {
-            std::stringstream ss;
-            ss << s;
-            double timestamp;
-            ss >> timestamp;
-            timestamps_.push_back(timestamp);
-        }
+    if (!ifs_timestamp) {
+        throw std::runtime_error("Could not load a timestamp file from " + timestamp_file_path);
     }
-
-    ifs_timestamp.close();
-
-    // load image file paths
-    const std::string img_dir_path = seq_dir_path + "/image_0/";
-    num_imgs_ = timestamps_.size();
-
-    img_file_paths_.clear();
-    for (unsigned int i = 0; i < num_imgs_; ++i) {
-        std::stringstream ss;
-        ss << std::setfill('0') << std::setw(6) << i;
-        img_file_paths_.push_back(img_dir_path + ss.str() + ".png");
-    }
-}
-
-std::vector<kitti_mono_sequence::frame> kitti_mono_sequence::get_frames() const {
-    std::vector<frame> frames;
-    for (unsigned int i = 0; i < num_imgs_; ++i) {
-        frames.emplace_back(frame{img_file_paths_.at(i), timestamps_.at(i)});
-    }
-    return frames;
-}
-
-kitti_stereo_sequence::kitti_stereo_sequence(const std::string& seq_dir_path) {
-    // load timestamps
-    const std::string timestamp_file_path = seq_dir_path + "/times.txt";
-    std::ifstream ifs_timestamp;
-    ifs_timestamp.open(timestamp_file_path.c_str());
 
     timestamps_.clear();
     while (!ifs_timestamp.eof()) {
@@ -70,11 +32,10 @@ kitti_stereo_sequence::kitti_stereo_sequence(const std::string& seq_dir_path) {
     // load image file paths
     const std::string left_img_dir_path = seq_dir_path + "/image_0/";
     const std::string right_img_dir_path = seq_dir_path + "/image_1/";
-    num_imgs_ = timestamps_.size();
 
     left_img_file_paths_.clear();
     right_img_file_paths_.clear();
-    for (unsigned int i = 0; i < num_imgs_; ++i) {
+    for (unsigned int i = 0; i < timestamps_.size(); ++i) {
         std::stringstream ss;
         ss << std::setfill('0') << std::setw(6) << i;
         left_img_file_paths_.push_back(left_img_dir_path + ss.str() + ".png");
@@ -82,9 +43,12 @@ kitti_stereo_sequence::kitti_stereo_sequence(const std::string& seq_dir_path) {
     }
 }
 
-std::vector<kitti_stereo_sequence::frame> kitti_stereo_sequence::get_frames() const {
+std::vector<kitti_sequence::frame> kitti_sequence::get_frames() const {
     std::vector<frame> frames;
-    for (unsigned int i = 0; i < num_imgs_; ++i) {
+    assert(timestamps_.size() == left_img_file_paths_.size());
+    assert(timestamps_.size() == right_img_file_paths_.size());
+    assert(left_img_file_paths_.size() == right_img_file_paths_.size());
+    for (unsigned int i = 0; i < timestamps_.size(); ++i) {
         frames.emplace_back(frame{left_img_file_paths_.at(i), right_img_file_paths_.at(i), timestamps_.at(i)});
     }
     return frames;

--- a/example/util/kitti_util.h
+++ b/example/util/kitti_util.h
@@ -1,32 +1,10 @@
-#ifndef KITTI_UTIL_H
-#define KITTI_UTIL_H
+#ifndef EXAMPLE_UTIL_KITTI_UTIL_H
+#define EXAMPLE_UTIL_KITTI_UTIL_H
 
 #include <string>
 #include <vector>
 
-class kitti_mono_sequence {
-public:
-    struct frame {
-        frame(const std::string& img_path, const double timestamp)
-                : img_path_(img_path), timestamp_(timestamp) {};
-
-        const std::string img_path_;
-        const double timestamp_;
-    };
-
-    explicit kitti_mono_sequence(const std::string& seq_dir_path);
-
-    virtual ~kitti_mono_sequence() = default;
-
-    std::vector<frame> get_frames() const;
-
-private:
-    std::vector<double> timestamps_;
-    std::vector<std::string> img_file_paths_;
-    unsigned int num_imgs_;
-};
-
-class kitti_stereo_sequence {
+class kitti_sequence {
 public:
     struct frame {
         frame(const std::string& left_img_path, const std::string& right_img_path, const double timestamp)
@@ -37,9 +15,9 @@ public:
         const double timestamp_;
     };
 
-    explicit kitti_stereo_sequence(const std::string& seq_dir_path);
+    explicit kitti_sequence(const std::string& seq_dir_path);
 
-    virtual ~kitti_stereo_sequence() = default;
+    virtual ~kitti_sequence() = default;
 
     std::vector<frame> get_frames() const;
 
@@ -47,7 +25,6 @@ private:
     std::vector<double> timestamps_;
     std::vector<std::string> left_img_file_paths_;
     std::vector<std::string> right_img_file_paths_;
-    unsigned int num_imgs_;
 };
 
-#endif // KITTI_UTIL_H
+#endif // EXAMPLE_UTIL_KITTI_UTIL_H


### PR DESCRIPTION
Thank you for your work!

On example codes, I noticed that `*_stereo_sequence` classes in the utilities can be shared in both `mono` and `stereo` tracking codes.
So I removed the classes for `mono` sequences and use the `stereo` classes for `mono` tracking as well.

In addition, on the codes for `run_image_slam` and `run_image_localization`, interfaces of the utility class are standardized according to the ones for KITTI and EuRoC datasets.