### PR TITLE
Avoid SEGV when a pre-build map is loaded

### DIFF
--- a/src/openvslam/data/graph_node.cc
+++ b/src/openvslam/data/graph_node.cc
@@ -322,8 +322,9 @@ bool graph_node::has_spanning_child(keyframe* keyfrm) const {
 
 void graph_node::add_loop_edge(keyframe* keyfrm) {
     std::lock_guard<std::mutex> lock(mtx_);
-    owner_keyfrm_->set_not_to_be_erased();
     loop_edges_.insert(keyfrm);
+    // cannot erase loop edges
+    owner_keyfrm_->set_not_to_be_erased();
 }
 
 std::set<keyframe*> graph_node::get_loop_edges() const {

--- a/src/openvslam/data/keyframe.cc
+++ b/src/openvslam/data/keyframe.cc
@@ -366,6 +366,11 @@ void keyframe::prepare_for_erasing() {
         return;
     }
 
+    // cannot erase if the frag is raised
+    if (cannot_be_erased_) {
+        return;
+    }
+
     // 1. raise the flag which indicates it has been erased
 
     will_be_erased_ = true;


### PR DESCRIPTION
fix #84