### PR TITLE
Fix error in camera::fisheye::constructor when Eigen is debug mode.

### DIFF
--- a/src/openvslam/camera/fisheye.cc
+++ b/src/openvslam/camera/fisheye.cc
@@ -19,7 +19,7 @@ fisheye::fisheye(const std::string& name, const setup_type_t& setup_type, const 
     cv_dist_params_ = (cv::Mat_<float>(4, 1) << k1_, k2_, k3_, k4_);
 
     eigen_cam_matrix_ << fx_, 0, cx_, 0, fy_, cy_, 0, 0, 1;
-    eigen_dist_params_ << k1_, k2_, k3_, k4_;
+    eigen_dist_params_ << k1_, k2_, k3_, k4_, 0;
 
     img_bounds_ = compute_image_bounds();
 


### PR DESCRIPTION
Hi, I encountered an error when Eigen is debug mode (EIGEN_NO_DEBUG is not defined).
Since eigen_dist_params_ have five elements, an error "Too few coefficients passed to comma initializer (operator<<)" occurred in _camera::fisheye::constructor_ when Eigen is debug mode.

Although I don't understand why you need eigen_cam_matrix_ and eigen_dist_params_, I didn't delete them for safety.

Thanks,