### PR TITLE
Avoid to crash when any keypoints cannot be extracted

### DIFF
--- a/src/openvslam/camera/fisheye.cc
+++ b/src/openvslam/camera/fisheye.cc
@@ -92,6 +92,12 @@ image_bounds fisheye::compute_image_bounds() const {
 }
 
 void fisheye::undistort_keypoints(const std::vector<cv::KeyPoint>& dist_keypt, std::vector<cv::KeyPoint>& undist_keypt) const {
+    // cv::fisheye::undistortPoints does not accept an empty input
+    if (dist_keypt.empty()) {
+        undist_keypt.clear();
+        return;
+    }
+
     // fill cv::Mat with distorted keypoints
     cv::Mat mat(dist_keypt.size(), 2, CV_32F);
     for (unsigned long idx = 0; idx < dist_keypt.size(); ++idx) {

--- a/src/openvslam/camera/perspective.cc
+++ b/src/openvslam/camera/perspective.cc
@@ -94,6 +94,12 @@ image_bounds perspective::compute_image_bounds() const {
 }
 
 void perspective::undistort_keypoints(const std::vector<cv::KeyPoint>& dist_keypts, std::vector<cv::KeyPoint>& undist_keypts) const {
+    // cv::undistortPoints does not accept an empty input
+    if (dist_keypts.empty()) {
+        undist_keypts.clear();
+        return;
+    }
+
     // fill cv::Mat with distorted keypoints
     cv::Mat mat(dist_keypts.size(), 2, CV_32F);
     for (unsigned long idx = 0; idx < dist_keypts.size(); ++idx) {

--- a/src/openvslam/match/stereo.cc
+++ b/src/openvslam/match/stereo.cc
@@ -95,7 +95,10 @@ void stereo::compute(std::vector<float>& stereo_x_right, std::vector<float>& dep
     // 相関の中央値を求める
     std::sort(correlation_and_idx_left.begin(), correlation_and_idx_left.end());
     const auto median_i = correlation_and_idx_left.size() / 2;
-    const float median_correlation = correlation_and_idx_left.at(median_i).first;
+    const float median_correlation =
+        correlation_and_idx_left.empty()
+            ? 0.0f
+            : correlation_and_idx_left.at(median_i).first;
     // 相関の中央値x2より相関が弱いものは破棄する
     const float correlation_thr = 2.0 * median_correlation;
 


### PR DESCRIPTION
This PR fixes 2 problems related to frames that have no keypoints:
- Assertions in `cv::undistortPoints` and `cv::fisheye::undistortPoints` will be failed when an input array is empty.
- Computing a median of correlations in `openvslam::stereo::compute` throws `std::out_of_range` when there are no matched points.