### PR TITLE
Refactor PnP solver

### DIFF
--- a/src/openvslam/module/relocalizer.cc
+++ b/src/openvslam/module/relocalizer.cc
@@ -56,7 +56,6 @@ bool relocalizer::relocalize(data::frame& curr_frm) {
 
         pnp_solvers.at(i) = std::unique_ptr<solve::pnp_solver>(new solve::pnp_solver(curr_frm.bearings_, curr_frm.keypts_,
                                                                                      curr_frm.scale_factors_, matched_landmarks.at(i)));
-        pnp_solvers.at(i)->set_ransac_parameters(0.99, 10, 300);
         ++num_valid_candidates;
     }
 
@@ -72,13 +71,12 @@ bool relocalizer::relocalize(data::frame& curr_frm) {
 
         // 1. PnP(+RANSAC)で姿勢を求める
 
-        std::vector<bool> is_inlier;
-
-        if (!pnp_solvers.at(i)->estimate()) {
+        pnp_solvers.at(i)->find_via_ransac(30);
+        if (!pnp_solvers.at(i)->solution_is_valid()) {
             continue;
         }
 
-        curr_frm.cam_pose_cw_ = pnp_solvers.at(i)->get_best_cam_pose_cw();
+        curr_frm.cam_pose_cw_ = pnp_solvers.at(i)->get_best_cam_pose();
         curr_frm.update_pose_params();
 
         // 2. pose optimizerを通す

--- a/src/openvslam/module/relocalizer.h
+++ b/src/openvslam/module/relocalizer.h
@@ -4,6 +4,7 @@
 #include "openvslam/match/bow_tree.h"
 #include "openvslam/match/projection.h"
 #include "openvslam/optimize/pose_optimizer.h"
+#include "openvslam/solve/pnp_solver.h"
 
 namespace openvslam {
 
@@ -16,32 +17,41 @@ namespace module {
 
 class relocalizer {
 public:
-    /**
-     * Constructor
-     */
+    //! Constructor
     explicit relocalizer(data::bow_database* bow_db,
                          const double bow_match_lowe_ratio = 0.75, const double proj_match_lowe_ratio = 0.9,
                          const unsigned int min_num_bow_matches = 20, const unsigned int min_num_valid_obs = 50);
 
-    /**
-     * Destructor
-     */
-    ~relocalizer();
+    //! Destructor
+    virtual ~relocalizer();
 
-    /**
-     * Relocalize the specified frame
-     */
+    //! Relocalize the specified frame
     bool relocalize(data::frame& curr_frm);
 
 private:
+    //! Extract valid (non-deleted) landmarks from landmark vector
+    std::vector<unsigned int> extract_valid_indices(const std::vector<data::landmark*>& landmarks) const;
+
+    //! Setup PnP solver with the specified 2D-3D matches
+    std::unique_ptr<solve::pnp_solver> setup_pnp_solver(const std::vector<unsigned int>& valid_indices,
+                                                        const eigen_alloc_vector<Vec3_t>& bearings,
+                                                        const std::vector<cv::KeyPoint>& keypts,
+                                                        const std::vector<data::landmark*>& matched_landmarks,
+                                                        const std::vector<float>& scale_factors) const;
+
+    //! BoW database
     data::bow_database* bow_db_;
 
+    //! minimum threshold of the number of BoW matches
     const unsigned int min_num_bow_matches_;
+    //! minimum threshold of the number of valid (= inlier after pose optimization) matches
     const unsigned int min_num_valid_obs_;
 
+    //! BoW matcher
     const match::bow_tree bow_matcher_;
+    //! projection matcher
     const match::projection proj_matcher_;
-
+    //! pose optimizer
     const optimize::pose_optimizer pose_optimizer_;
 };
 

--- a/src/openvslam/solve/pnp_solver.h
+++ b/src/openvslam/solve/pnp_solver.h
@@ -1,55 +1,85 @@
 #ifndef OPENVSLAM_SOLVE_PNP_SOLVER_H
 #define OPENVSLAM_SOLVE_PNP_SOLVER_H
 
-#include "openvslam/data/landmark.h"
-#include "openvslam/data/frame.h"
 #include "openvslam/util/converter.h"
 
-#include <opencv2/core/core.hpp>
+#include <vector>
 
 namespace openvslam {
+
+namespace data {
+class landmark;
+} // namespace data
+
 namespace solve {
 
 class pnp_solver {
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+    //! Constructor
     pnp_solver(const eigen_alloc_vector<Vec3_t>& bearings, const std::vector<cv::KeyPoint>& keypts,
-               const std::vector<float>& scale_factors, const std::vector<data::landmark*>& assoc_lms);
+               const std::vector<float>& scale_factors, const std::vector<data::landmark*>& assoc_lms,
+               const unsigned int min_num_inliers = 10);
 
-    ~pnp_solver();
+    //! Destructor
+    virtual ~pnp_solver();
 
-    void set_ransac_parameters(const float probability = 0.99, const unsigned int min_num_inliers = 10, const unsigned int max_num_iters = 500);
+    //! Find the most reliable camera pose via RASNAC
+    void find_via_ransac(const unsigned int max_num_iter, const bool recompute = true);
 
-    bool estimate();
-
-    std::vector<unsigned int> get_inlier_indices() const {
-        std::vector<unsigned int> inlier_indices;
-        inlier_indices.reserve(valid_indices_.size());
-        for (unsigned int i = 0; i < valid_indices_.size(); ++i) {
-            if (best_is_inlier_.at(i)) {
-                inlier_indices.push_back(valid_indices_.at(i));
-            }
-        }
-        return inlier_indices;
+    //! Check if the solution is valid or not
+    bool solution_is_valid() const {
+        return solution_is_valid_;
     }
 
-    Mat33_t get_best_rot_cw() const {
+    //! Get the most reliable rotation (as the world reference)
+    Mat33_t get_best_rotation() const {
         return best_rot_cw_;
     }
 
-    Vec3_t get_best_trans_cw() const {
+    //! Get the most reliable translation (as the world reference)
+    Vec3_t get_best_translation() const {
         return best_trans_cw_;
     }
 
-    Mat44_t get_best_cam_pose_cw() const {
+    //! Get the most reliable camera pose (as the world reference)
+    Mat44_t get_best_cam_pose() const {
         return util::converter::to_eigen_cam_pose(best_rot_cw_, best_trans_cw_);
     }
 
-    static constexpr unsigned int min_num_correspondences_ = 4;
+    std::vector<unsigned int> get_inlier_indices() const;
 
 private:
-    unsigned int count_inliers(const Mat33_t& rot_cw, const Vec3_t& trans_cw, std::vector<bool>& is_inlier);
+    //! Check inliers of 2D-3D matches
+    //! (Note: inlier flags are set to_inlier_match and the number of inliers is returned)
+    unsigned int check_inliers(const Mat33_t& rot_cw, const Vec3_t& trans_cw, std::vector<bool>& is_inlier);
+
+    //! minimum number of inliers
+    //! (Note: if the number of inliers is less than this, solution is regarded as invalid)
+    const unsigned int min_num_inliers_;
+
+    // 以下のvectorは要素ごとに対応している
+    //! 有効な対応の特徴点index
+    std::vector<unsigned int> valid_indices_;
+    //! bearing vector
+    eigen_alloc_vector<Vec3_t> valid_bearings_;
+    //! 3次元点
+    eigen_alloc_vector<Vec3_t> valid_landmarks_;
+    //! 許容する最大誤差
+    std::vector<float> max_cos_errors_;
+
+    //! solution is valid or not
+    bool solution_is_valid_ = false;
+    //! most reliable rotation
+    Mat33_t best_rot_cw_;
+    //! most reliable translation
+    Vec3_t best_trans_cw_;
+    //! inlier matches computed via RANSAC
+    std::vector<bool> is_inlier_match;
+
+    //-----------------------------------------
+    // quoted from EPnP implementation
 
     void reset_correspondences();
 
@@ -110,30 +140,6 @@ private:
 
     unsigned int num_matches_ = 0;
     unsigned int max_num_correspondences_ = 0;
-
-    // 対応する2D-3D点の情報
-    //! 有効な対応数
-    unsigned int num_valid_correspondences_;
-
-    // 以下のvectorは要素ごとに対応している
-    //! 有効な対応の特徴点index
-    std::vector<unsigned int> valid_indices_;
-    //! bearing vector
-    eigen_alloc_vector<Vec3_t> valid_bearings_;
-    //! 3次元点
-    eigen_alloc_vector<Vec3_t> valid_landmarks_;
-    //! 許容する最大誤差
-    std::vector<float> max_cos_errors_;
-
-    //! RANSACのベストモデル
-    Mat33_t best_rot_cw_;
-    Vec3_t best_trans_cw_;
-    std::vector<bool> best_is_inlier_;
-
-    //! RANSACのパラメータ
-    float probability_;
-    unsigned int min_num_inliers_;
-    unsigned int max_num_iters_;
 };
 
 } // namespace solve

--- a/src/openvslam/solve/pnp_solver.h
+++ b/src/openvslam/solve/pnp_solver.h
@@ -6,11 +6,6 @@
 #include <vector>
 
 namespace openvslam {
-
-namespace data {
-class landmark;
-} // namespace data
-
 namespace solve {
 
 class pnp_solver {
@@ -18,14 +13,14 @@ public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
     //! Constructor
-    pnp_solver(const eigen_alloc_vector<Vec3_t>& bearings, const std::vector<cv::KeyPoint>& keypts,
-               const std::vector<float>& scale_factors, const std::vector<data::landmark*>& assoc_lms,
+    pnp_solver(const eigen_alloc_vector<Vec3_t>& valid_bearings, const std::vector<cv::KeyPoint>& valid_keypts,
+               const eigen_alloc_vector<Vec3_t>& valid_landmarks, const std::vector<float>& scale_factors,
                const unsigned int min_num_inliers = 10);
 
     //! Destructor
     virtual ~pnp_solver();
 
-    //! Find the most reliable camera pose via RASNAC
+    //! Find the most reliable camera pose via RANSAC
     void find_via_ransac(const unsigned int max_num_iter, const bool recompute = true);
 
     //! Check if the solution is valid or not
@@ -48,26 +43,29 @@ public:
         return util::converter::to_eigen_cam_pose(best_rot_cw_, best_trans_cw_);
     }
 
-    std::vector<unsigned int> get_inlier_indices() const;
+    //! Get the inlier flags estimated via RANSAC
+    std::vector<bool> get_inlier_flags() const {
+        return is_inlier_match;
+    }
 
 private:
     //! Check inliers of 2D-3D matches
     //! (Note: inlier flags are set to_inlier_match and the number of inliers is returned)
     unsigned int check_inliers(const Mat33_t& rot_cw, const Vec3_t& trans_cw, std::vector<bool>& is_inlier);
 
+    //! the number of 2D-3D matches
+    const unsigned int num_matches_;
+    // the following vectors are corresponded as element-wise
+    //! bearing vector
+    eigen_alloc_vector<Vec3_t> valid_bearings_;
+    //! 3D point
+    eigen_alloc_vector<Vec3_t> valid_landmarks_;
+    //! acceptable maximum error
+    std::vector<float> max_cos_errors_;
+
     //! minimum number of inliers
     //! (Note: if the number of inliers is less than this, solution is regarded as invalid)
     const unsigned int min_num_inliers_;
-
-    // 以下のvectorは要素ごとに対応している
-    //! 有効な対応の特徴点index
-    std::vector<unsigned int> valid_indices_;
-    //! bearing vector
-    eigen_alloc_vector<Vec3_t> valid_bearings_;
-    //! 3次元点
-    eigen_alloc_vector<Vec3_t> valid_landmarks_;
-    //! 許容する最大誤差
-    std::vector<float> max_cos_errors_;
 
     //! solution is valid or not
     bool solution_is_valid_ = false;
@@ -138,7 +136,7 @@ private:
 
     double cws[4][3], ccs[4][3];
 
-    unsigned int num_matches_ = 0;
+    unsigned int num_correspondences_ = 0;
     unsigned int max_num_correspondences_ = 0;
 };
 

--- a/src/openvslam/util/fancy_index.h
+++ b/src/openvslam/util/fancy_index.h
@@ -1,0 +1,71 @@
+#ifndef OPENVSLAM_UTIL_FANCY_INDEX_H
+#define OPENVSLAM_UTIL_FANCY_INDEX_H
+
+#include "openvslam/type.h"
+
+#include <vector>
+#include <type_traits>
+
+namespace openvslam {
+namespace util {
+
+template<typename T, typename U>
+std::vector<T> resample_by_indices(const std::vector<T>& elements, const std::vector<U>& indices) {
+    static_assert(std::is_integral<U>(), "the element type of indices must be integer");
+
+    std::vector<T> resampled;
+    resampled.reserve(elements.size());
+    for (const auto idx : indices) {
+        resampled.push_back(elements.at(idx));
+    }
+
+    return resampled;
+}
+
+template<typename T, typename U>
+eigen_alloc_vector<T> resample_by_indices(const eigen_alloc_vector<T>& elements, const std::vector<U>& indices) {
+    static_assert(std::is_integral<U>(), "the element type of indices must be integer");
+
+    eigen_alloc_vector<T> resampled;
+    resampled.reserve(elements.size());
+    for (const auto idx : indices) {
+        resampled.push_back(elements.at(idx));
+    }
+
+    return resampled;
+}
+
+template<typename T>
+std::vector<T> resample_by_indices(const std::vector<T>& elements, const std::vector<bool>& indices) {
+    assert(elements.size() == indices.size());
+
+    std::vector<T> resampled;
+    resampled.reserve(elements.size());
+    for (unsigned int idx = 0; idx < elements.size(); ++idx) {
+        if (indices.at(idx)) {
+            resampled.push_back(elements.at(idx));
+        }
+    }
+
+    return resampled;
+}
+
+template<typename T>
+eigen_alloc_vector<T> resample_by_indices(const eigen_alloc_vector<T>& elements, const std::vector<bool>& indices) {
+    assert(elements.size() == indices.size());
+
+    eigen_alloc_vector<T> resampled;
+    resampled.reserve(elements.size());
+    for (unsigned int idx = 0; idx < elements.size(); ++idx) {
+        if (indices.at(idx)) {
+            resampled.push_back(elements.at(idx));
+        }
+    }
+
+    return resampled;
+}
+
+} // namespace util
+} // namespace openvslam
+
+#endif // OPENVSLAM_UTIL_FANCY_INDEX_H

--- a/test/openvslam/util/fancy_index.cc
+++ b/test/openvslam/util/fancy_index.cc
@@ -1,0 +1,196 @@
+#include "openvslam/type.h"
+#include "openvslam/util/fancy_index.h"
+
+#include <gtest/gtest.h>
+
+using namespace openvslam;
+
+TEST(fancy_index, resample_int) {
+    constexpr unsigned int num_elements = 200;
+    constexpr unsigned int interval = 4;
+
+    // function for testing
+    auto func = [](const unsigned int value) {
+        return value * 2 + 1;
+    };
+
+    // create original element vector and indices to resample
+    std::vector<int> elements(num_elements);
+    std::vector<unsigned int> indices;
+    std::vector<bool> index_flags(num_elements, false);
+    for (unsigned int idx = 0; idx < num_elements; ++idx) {
+        elements.at(idx) = func(idx);
+        // select the elements whose values can be divided by interval
+        if (idx % interval == 0) {
+            indices.push_back(idx);
+            index_flags.at(idx) = true;
+        }
+    }
+
+    {
+        // resample elements with indices
+        const auto resampled = util::resample_by_indices(elements, indices);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx), elements.at(idx * interval));
+        }
+    }
+
+    {
+        // resample elements with flags
+        const auto resampled = util::resample_by_indices(elements, index_flags);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx), elements.at(idx * interval));
+        }
+    }
+}
+
+TEST(fancy_index, resample_double) {
+    constexpr unsigned int num_elements = 200;
+    constexpr unsigned int interval = 1;
+
+    // function for testing
+    auto func = [](const double value) {
+        return value * 2.5 - 4.6;
+    };
+
+    // create original element vector and indices to resample
+    std::vector<double> elements(num_elements);
+    std::vector<unsigned int> indices;
+    std::vector<bool> index_flags(num_elements, false);
+    for (unsigned int idx = 0; idx < num_elements; ++idx) {
+        elements.at(idx) = func(idx);
+        // select the elements whose values can be divided by interval
+        if (idx % interval == 0) {
+            indices.push_back(idx);
+            index_flags.at(idx) = true;
+        }
+    }
+
+    {
+        // resample elements with indices
+        const auto resampled = util::resample_by_indices(elements, indices);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx), elements.at(idx * interval));
+        }
+    }
+
+    {
+        // resample elements with flags
+        const auto resampled = util::resample_by_indices(elements, index_flags);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx), elements.at(idx * interval));
+        }
+    }
+}
+
+TEST(fancy_index, resample_eigen) {
+    constexpr unsigned int num_elements = 200;
+    constexpr unsigned int interval = 6;
+
+    // function for testing
+    auto func = [](const double value) {
+        return Vec3_t{value * 2.5 - 4.6, value * 1.1 + 5.1, value * 4.9 - 0.5};
+    };
+
+    // create original element vector and indices to resample
+    eigen_alloc_vector<Vec3_t> elements(num_elements);
+    std::vector<unsigned int> indices;
+    std::vector<bool> index_flags(num_elements, false);
+    for (unsigned int idx = 0; idx < num_elements; ++idx) {
+        elements.at(idx) = func(idx);
+        // select the elements whose values can be divided by interval
+        if (idx % interval == 0) {
+            indices.push_back(idx);
+            index_flags.at(idx) = true;
+        }
+    }
+
+    {
+        // resample elements with indices
+        const auto resampled = util::resample_by_indices(elements, indices);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx), elements.at(idx * interval));
+        }
+    }
+
+    {
+        // resample elements with flags
+        const auto resampled = util::resample_by_indices(elements, index_flags);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx), elements.at(idx * interval));
+        }
+    }
+}
+
+TEST(fancy_index, resample_keypoint) {
+    constexpr unsigned int num_elements = 200;
+    constexpr unsigned int interval = 7;
+
+    // function for testing
+    auto func = [](const double value) {
+        return cv::KeyPoint(value * 1.5, value * 5.1, value / 3.1);
+    };
+
+    // create original element vector and indices to resample
+    std::vector<cv::KeyPoint> elements(num_elements);
+    std::vector<unsigned int> indices;
+    std::vector<bool> index_flags(num_elements, false);
+    for (unsigned int idx = 0; idx < num_elements; ++idx) {
+        elements.at(idx) = func(idx);
+        // select the elements whose values can be divided by interval
+        if (idx % interval == 0) {
+            indices.push_back(idx);
+            index_flags.at(idx) = true;
+        }
+    }
+
+    {
+        // resample elements with indices
+        const auto resampled = util::resample_by_indices(elements, indices);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx).pt, elements.at(idx * interval).pt);
+            EXPECT_EQ(resampled.at(idx).size, elements.at(idx * interval).size);
+        }
+    }
+
+    {
+        // resample elements with indices
+        const auto resampled = util::resample_by_indices(elements, index_flags);
+
+        // check vector size
+        EXPECT_EQ(resampled.size(), indices.size());
+        // check if the specified elements is resampled or not
+        for (unsigned int idx = 0; idx < indices.size(); ++idx) {
+            EXPECT_EQ(resampled.at(idx).pt, elements.at(idx * interval).pt);
+            EXPECT_EQ(resampled.at(idx).size, elements.at(idx * interval).size);
+        }
+    }
+}


### PR DESCRIPTION
Refactor the PnP solver for reimplementation of EPnP algorithm

- Reformat the constructor not to depend on `data::landmark` class
- Reformat the interfaces
- Modify the relocalizer module accordingly