### PR TITLE
Accept portrait imagery/video as input

### DIFF
--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -474,7 +474,6 @@ std::vector<cv::KeyPoint> orb_extractor::distribute_keypoints_via_tree(const std
 
 std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<cv::KeyPoint>& keypts_to_distribute,
                                                               const int min_x, const int max_x, const int min_y, const int max_y) const {
-
     // The aspect ratio of the target area for keypoint detection
     const auto ratio = static_cast<double>(max_x - min_x) / (max_y - min_y);
     // The width and height of the patches allocated to the initial node
@@ -482,17 +481,17 @@ std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<
     // The number of columns or rows
     unsigned int num_x_grid, num_y_grid;
 
-    if (ratio > 1){
+    if (ratio > 1) {
         // If the aspect ratio is greater than 1, the patches are made in a horizontal direction
         num_x_grid = std::round(ratio);
         num_y_grid = 1;
         delta_x = static_cast<double>(max_x - min_x) / num_x_grid;
         delta_y = max_y - min_y;
     }
-    else{
+    else {
         // If the aspect ratio is less than 1, the patches are made in a vertical direction
         num_x_grid = 1;
-        num_y_grid = std::round(1/ratio);
+        num_y_grid = std::round(1 / ratio);
         delta_x = max_x - min_y;
         delta_y = static_cast<double>(max_y - min_y) / num_y_grid;
     }
@@ -516,7 +515,7 @@ std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<
         const unsigned int iy = i / num_x_grid;
 
         node.pt_begin_ = cv::Point2i(delta_x * ix, delta_y * iy);
-        node.pt_end_ = cv::Point2i(delta_x * (ix+1), delta_y * (iy+1));
+        node.pt_end_ = cv::Point2i(delta_x * (ix + 1), delta_y * (iy + 1));
         node.keypts_.reserve(keypts_to_distribute.size());
 
         nodes.push_back(node);

--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -474,10 +474,31 @@ std::vector<cv::KeyPoint> orb_extractor::distribute_keypoints_via_tree(const std
 
 std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<cv::KeyPoint>& keypts_to_distribute,
                                                               const int min_x, const int max_x, const int min_y, const int max_y) const {
+
+    // The aspect ratio of the target area for keypoint detection
+    const auto ratio = static_cast<double>(max_x - min_x) / (max_y - min_y);
+    // The width and height of the patches allocated to the initial node
+    double delta_x, delta_y;
+    // The number of columns or rows
+    unsigned int num_x_grid, num_y_grid;
+
+    if (ratio > 1){
+        // If the aspect ratio is greater than 1, the patches are made in a horizontal direction
+        num_x_grid = std::round(ratio);
+        num_y_grid = 1;
+        delta_x = static_cast<double>(max_x - min_x) / num_x_grid;
+        delta_y = max_y - min_y;
+    }
+    else{
+        // If the aspect ratio is less than 1, the patches are made in a vertical direction
+        num_x_grid = 1;
+        num_y_grid = std::round(1/ratio);
+        delta_x = max_x - min_y;
+        delta_y = static_cast<double>(max_y - min_y) / num_y_grid;
+    }
+
     // The number of the initial nodes
-    const unsigned int num_initial_nodes = std::round(static_cast<double>(max_x - min_x) / (max_y - min_y));
-    // Width of patches allocated to the initial node
-    const auto delta_x = static_cast<double>(max_x - min_x) / num_initial_nodes;
+    const unsigned int num_initial_nodes = num_x_grid * num_y_grid;
 
     // A list of node
     std::list<orb_extractor_node> nodes;
@@ -490,8 +511,12 @@ std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<
     for (unsigned int i = 0; i < num_initial_nodes; ++i) {
         orb_extractor_node node;
 
-        node.pt_begin_ = cv::Point2i(delta_x * static_cast<double>(i), 0);
-        node.pt_end_ = cv::Point2i(delta_x * static_cast<double>(i + 1), max_y - min_y);
+        // x / y index of the node's patch in the grid
+        const unsigned int ix = i % num_x_grid;
+        const unsigned int iy = i / num_x_grid;
+
+        node.pt_begin_ = cv::Point2i(delta_x * ix, delta_y * iy);
+        node.pt_end_ = cv::Point2i(delta_x * (ix+1), delta_y * (iy+1));
         node.keypts_.reserve(keypts_to_distribute.size());
 
         nodes.push_back(node);
@@ -500,7 +525,12 @@ std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<
 
     // Assign all keypoints to initial nodes which own keypoint's position
     for (const auto& keypt : keypts_to_distribute) {
-        initial_nodes.at(keypt.pt.x / delta_x)->keypts_.push_back(keypt);
+        // x / y index of the patch where the keypt place
+        const unsigned int ix = keypt.pt.x / delta_x;
+        const unsigned int iy = keypt.pt.y / delta_y;
+
+        const unsigned int node_idx = ix + iy * num_x_grid;
+        initial_nodes.at(node_idx)->keypts_.push_back(keypt);
     }
 
     auto iter = nodes.begin();

--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -489,7 +489,7 @@ std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<
         delta_y = max_y - min_y;
     }
     else {
-        // If the aspect ratio is less than 1, the patches are made in a vertical direction
+        // If the aspect ratio is equal to or less than 1, the patches are made in a vertical direction
         num_x_grid = 1;
         num_y_grid = std::round(1 / ratio);
         delta_x = max_x - min_y;
@@ -524,7 +524,7 @@ std::list<orb_extractor_node> orb_extractor::initialize_nodes(const std::vector<
 
     // Assign all keypoints to initial nodes which own keypoint's position
     for (const auto& keypt : keypts_to_distribute) {
-        // x / y index of the patch where the keypt place
+        // x / y index of the patch where the keypt is placed
         const unsigned int ix = keypt.pt.x / delta_x;
         const unsigned int iy = keypt.pt.y / delta_y;
 

--- a/test/openvslam/feature/orb_extractor.cc
+++ b/test/openvslam/feature/orb_extractor.cc
@@ -326,3 +326,74 @@ TEST(orb_extractor, extract_with_rectangle_mask_3) {
         cv::waitKey(0);
     }
 }
+
+TEST(orb_extractor, extract_toy_sample_3) {
+    const auto params = feature::orb_params();
+    auto extractor = feature::orb_extractor(params);
+
+    // image
+    auto img = cv::Mat(1200, 600, CV_8UC1);
+    img = 255;
+    cv::rectangle(img, cv::Point2i(300, 600), cv::Point2i(600, 1200), cv::Scalar(0), -1, cv::LINE_AA);
+    // mask (無効)
+    const auto mask = cv::Mat();
+
+    std::vector<cv::KeyPoint> keypts;
+    cv::Mat desc;
+    extractor.extract(img, mask, keypts, desc);
+
+    EXPECT_GT(keypts.size(), 0);
+    EXPECT_GT(desc.rows, 0);
+    EXPECT_EQ(keypts.size(), desc.rows);
+    EXPECT_EQ(desc.type(), CV_8U);
+
+    // スケールを考慮して誤差を測定
+    for (const auto& keypt : keypts) {
+        EXPECT_NEAR(keypt.pt.x, 300, 2.0 * extractor.get_scale_factors().at(keypt.octave));
+        EXPECT_NEAR(keypt.pt.y, 600, 2.0 * extractor.get_scale_factors().at(keypt.octave));
+    }
+}
+
+TEST(orb_extractor, extract_without_mask_3) {
+    const auto params = feature::orb_params();
+    auto extractor = feature::orb_extractor(params);
+
+    // image
+    const auto img_land = cv::imread(std::string(TEST_DATA_DIR) + "./equirectangular_image_001.jpg", cv::IMREAD_GRAYSCALE);
+    // Rotate the landscape image to make it portrait one
+    cv::Mat img;
+    cv::rotate(img_land, img, cv::ROTATE_90_CLOCKWISE);
+    // mask (無効)
+    const auto mask = cv::Mat();
+
+    std::vector<cv::KeyPoint> keypts;
+    cv::Mat desc;
+    extractor.extract(img, mask, keypts, desc);
+
+    EXPECT_GT(keypts.size(), 0);
+    EXPECT_GT(desc.rows, 0);
+    EXPECT_EQ(keypts.size(), desc.rows);
+    EXPECT_EQ(desc.type(), CV_8U);
+}
+
+TEST(orb_extractor, extract_without_mask_4) {
+    const auto params = feature::orb_params();
+    auto extractor = feature::orb_extractor(params);
+
+    // image
+    const auto img_land = cv::imread(std::string(TEST_DATA_DIR) + "./equirectangular_image_002.jpg", cv::IMREAD_GRAYSCALE);
+    // Rotate the landscape image to make it portrait one
+    cv::Mat img;
+    cv::rotate(img_land, img, cv::ROTATE_90_CLOCKWISE);
+    // mask (無効)
+    const auto mask = cv::Mat();
+
+    std::vector<cv::KeyPoint> keypts;
+    cv::Mat desc;
+    extractor.extract(img, mask, keypts, desc);
+
+    EXPECT_GT(keypts.size(), 0);
+    EXPECT_GT(desc.rows, 0);
+    EXPECT_EQ(keypts.size(), desc.rows);
+    EXPECT_EQ(desc.type(), CV_8U);
+}


### PR DESCRIPTION
Fix the crash when the portrait images or videos are feed.

When any portrait images are given as input, the orb feature extractor made crashes due to only landscape imagery input are assumed. 
In order to fix the problem, I make some additional processes to accept the portrait images or videos.