### PR TITLE
Wrong score computation in Fundamental and Homographysolver

### DIFF
--- a/src/openvslam/solve/fundamental_solver.cc
+++ b/src/openvslam/solve/fundamental_solver.cc
@@ -15,7 +15,7 @@ void fundamental_solver::find_via_ransac(const unsigned int max_num_iter, const 
     const auto num_matches = static_cast<unsigned int>(matches_12_.size());
 
     // 0. Normalize keypoint coordinates
-
+    solution_is_valid_ = false;
     // apply normalization
     std::vector<cv::Point2f> normalized_keypts_1, normalized_keypts_2;
     Mat33_t transform_1, transform_2;
@@ -189,10 +189,6 @@ float fundamental_solver::check_inliers(const Mat33_t& F_21, std::vector<bool>& 
             is_inlier_match.at(i) = false;
             continue;
         }
-        else {
-            is_inlier_match.at(i) = true;
-            score += score_thr - chi_sq_2;
-        }
 
         // 2. Transform a point in shot 2 to the epipolar line in shot 1,
         //    then compute a transfer error (= dot product)
@@ -212,7 +208,10 @@ float fundamental_solver::check_inliers(const Mat33_t& F_21, std::vector<bool>& 
         }
         else {
             is_inlier_match.at(i) = true;
+            //Only compute the score for valid inliers
             score += score_thr - chi_sq_1;
+            score += score_thr - chi_sq_2;
+
         }
     }
 

--- a/src/openvslam/solve/homography_solver.cc
+++ b/src/openvslam/solve/homography_solver.cc
@@ -14,7 +14,7 @@ void homography_solver::find_via_ransac(const unsigned int max_num_iter, const b
     const auto num_matches = static_cast<unsigned int>(matches_12_.size());
 
     // 0. Normalize keypoint coordinates
-
+    solution_is_valid_ = false;
     // apply normalization
     std::vector<cv::Point2f> normalized_keypts_1, normalized_keypts_2;
     Mat33_t transform_1, transform_2;
@@ -281,10 +281,7 @@ float homography_solver::check_inliers(const Mat33_t& H_21, std::vector<bool>& i
             is_inlier_match.at(i) = false;
             continue;
         }
-        else {
-            is_inlier_match.at(i) = true;
-            score += chi_sq_thr - chi_sq_1;
-        }
+
 
         // 2. Transform a point in shot 2 to the epipolar line in shot 1,
         //    then compute a transfer error (= dot product)
@@ -304,7 +301,10 @@ float homography_solver::check_inliers(const Mat33_t& H_21, std::vector<bool>& i
         }
         else {
             is_inlier_match.at(i) = true;
+            //Only add to the score for valid matches
             score += chi_sq_thr - chi_sq_2;
+            score += chi_sq_thr - chi_sq_1;
+
         }
     }
 


### PR DESCRIPTION
If the first match is valid and the second match invalid, the match is considered an outlier but the score is greater than 0 (since it was increased for the first match).
If RANSAC doesn't find any valid sets, then "compute_H_21" is called with 0 keypts, which results in a segmentation fault.
