### PR TITLE
Build time improvements through #include changes

### DIFF
--- a/3rd/json/include/nlohmann/json_fwd.hpp
+++ b/3rd/json/include/nlohmann/json_fwd.hpp
@@ -1,0 +1,58 @@
+#ifndef INCLUDE_NLOHMANN_JSON_FWD_HPP_
+#define INCLUDE_NLOHMANN_JSON_FWD_HPP_
+
+#include <cstdint> // int64_t, uint64_t
+#include <map> // map
+#include <memory> // allocator
+#include <string> // string
+#include <vector> // vector
+
+/*!
+@brief namespace for Niels Lohmann
+@see https://github.com/nlohmann
+@since version 1.0.0
+*/
+namespace nlohmann
+{
+/*!
+@brief default JSONSerializer template argument
+This serializer ignores the template arguments and uses ADL
+([argument-dependent lookup](https://en.cppreference.com/w/cpp/language/adl))
+for serialization.
+*/
+template<typename T = void, typename SFINAE = void>
+struct adl_serializer;
+
+template<template<typename U, typename V, typename... Args> class ObjectType =
+         std::map,
+         template<typename U, typename... Args> class ArrayType = std::vector,
+         class StringType = std::string, class BooleanType = bool,
+         class NumberIntegerType = std::int64_t,
+         class NumberUnsignedType = std::uint64_t,
+         class NumberFloatType = double,
+         template<typename U> class AllocatorType = std::allocator,
+         template<typename T, typename SFINAE = void> class JSONSerializer =
+         adl_serializer>
+class basic_json;
+
+/*!
+@brief JSON Pointer
+A JSON pointer defines a string syntax for identifying a specific value
+within a JSON document. It can be used with functions `at` and
+`operator[]`. Furthermore, JSON pointers are the base for JSON patches.
+@sa [RFC 6901](https://tools.ietf.org/html/rfc6901)
+@since version 2.0.0
+*/
+template<typename BasicJsonType>
+class json_pointer;
+
+/*!
+@brief default JSON class
+This type is the default specialization of the @ref basic_json class which
+uses the standard template types.
+@since version 1.0.0
+*/
+using json = basic_json<>;
+}  // namespace nlohmann
+
+#endif  // INCLUDE_NLOHMANN_JSON_FWD_HPP_

--- a/example/run_camera_localization.cc
+++ b/example/run_camera_localization.cc
@@ -12,6 +12,9 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_camera_slam.cc
+++ b/example/run_camera_slam.cc
@@ -13,6 +13,9 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -18,6 +18,7 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_image_localization.cc
+++ b/example/run_image_localization.cc
@@ -14,6 +14,7 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_image_slam.cc
+++ b/example/run_image_slam.cc
@@ -14,6 +14,7 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_kitti_slam.cc
+++ b/example/run_kitti_slam.cc
@@ -17,6 +17,7 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_tum_rgbd_slam.cc
+++ b/example/run_tum_rgbd_slam.cc
@@ -17,6 +17,7 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_video_localization.cc
+++ b/example/run_video_localization.cc
@@ -12,6 +12,8 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/videoio.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/example/run_video_slam.cc
+++ b/example/run_video_slam.cc
@@ -12,6 +12,8 @@
 #include <numeric>
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/videoio.hpp>
 #include <spdlog/spdlog.h>
 #include <popl.hpp>
 

--- a/src/openvslam/camera/base.cc
+++ b/src/openvslam/camera/base.cc
@@ -1,5 +1,7 @@
 #include "openvslam/camera/base.h"
 
+#include <iostream>
+
 #include <spdlog/spdlog.h>
 
 namespace openvslam {

--- a/src/openvslam/camera/base.h
+++ b/src/openvslam/camera/base.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <limits>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 #include <yaml-cpp/yaml.h>
 #include <nlohmann/json_fwd.hpp>
 

--- a/src/openvslam/camera/base.h
+++ b/src/openvslam/camera/base.h
@@ -8,7 +8,7 @@
 
 #include <opencv2/opencv.hpp>
 #include <yaml-cpp/yaml.h>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace openvslam {
 namespace camera {

--- a/src/openvslam/camera/equirectangular.cc
+++ b/src/openvslam/camera/equirectangular.cc
@@ -1,6 +1,7 @@
 #include "openvslam/camera/equirectangular.h"
 
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 namespace openvslam {
 namespace camera {

--- a/src/openvslam/camera/fisheye.cc
+++ b/src/openvslam/camera/fisheye.cc
@@ -1,6 +1,7 @@
 #include "openvslam/camera/fisheye.h"
 
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 namespace openvslam {
 namespace camera {

--- a/src/openvslam/camera/fisheye.cc
+++ b/src/openvslam/camera/fisheye.cc
@@ -1,5 +1,7 @@
 #include "openvslam/camera/fisheye.h"
 
+#include <iostream>
+
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 

--- a/src/openvslam/camera/fisheye.h
+++ b/src/openvslam/camera/fisheye.h
@@ -3,6 +3,8 @@
 
 #include "openvslam/camera/base.h"
 
+#include <opencv2/calib3d.hpp>
+
 namespace openvslam {
 namespace camera {
 

--- a/src/openvslam/camera/perspective.cc
+++ b/src/openvslam/camera/perspective.cc
@@ -1,5 +1,7 @@
 #include "openvslam/camera/perspective.h"
 
+#include <iostream>
+
 #include <spdlog/spdlog.h>
 #include <nlohmann/json.hpp>
 

--- a/src/openvslam/camera/perspective.cc
+++ b/src/openvslam/camera/perspective.cc
@@ -1,6 +1,7 @@
 #include "openvslam/camera/perspective.h"
 
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 namespace openvslam {
 namespace camera {

--- a/src/openvslam/camera/perspective.h
+++ b/src/openvslam/camera/perspective.h
@@ -3,7 +3,11 @@
 
 #include "openvslam/camera/base.h"
 
+#if CV_MAJOR_VERSION == 3
+#include <opencv2/imgproc.hpp>
+#else if CV_MAJOR_VERSION == 4
 #include <opencv2/calib3d.hpp>
+#endif
 
 namespace openvslam {
 namespace camera {

--- a/src/openvslam/camera/perspective.h
+++ b/src/openvslam/camera/perspective.h
@@ -3,6 +3,8 @@
 
 #include "openvslam/camera/base.h"
 
+#include <opencv2/calib3d.hpp>
+
 namespace openvslam {
 namespace camera {
 

--- a/src/openvslam/config.cc
+++ b/src/openvslam/config.cc
@@ -3,6 +3,7 @@
 #include "openvslam/camera/fisheye.h"
 #include "openvslam/camera/equirectangular.h"
 
+#include <iostream>
 #include <memory>
 
 #include <spdlog/spdlog.h>

--- a/src/openvslam/data/camera_database.cc
+++ b/src/openvslam/data/camera_database.cc
@@ -5,6 +5,7 @@
 #include "openvslam/data/camera_database.h"
 
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 namespace openvslam {
 namespace data {

--- a/src/openvslam/data/camera_database.h
+++ b/src/openvslam/data/camera_database.h
@@ -4,7 +4,7 @@
 #include <mutex>
 #include <unordered_map>
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace openvslam {
 

--- a/src/openvslam/data/common.cc
+++ b/src/openvslam/data/common.cc
@@ -1,5 +1,7 @@
 #include "openvslam/data/common.h"
 
+#include <nlohmann/json.hpp>
+
 namespace openvslam {
 namespace data {
 

--- a/src/openvslam/data/common.h
+++ b/src/openvslam/data/common.h
@@ -4,8 +4,7 @@
 #include "openvslam/type.h"
 #include "openvslam/camera/base.h"
 
-#include <opencv2/opencv.hpp>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace openvslam {
 namespace data {

--- a/src/openvslam/data/common.h
+++ b/src/openvslam/data/common.h
@@ -4,6 +4,7 @@
 #include "openvslam/type.h"
 #include "openvslam/camera/base.h"
 
+#include <opencv2/core.hpp>
 #include <nlohmann/json_fwd.hpp>
 
 namespace openvslam {

--- a/src/openvslam/data/frame.h
+++ b/src/openvslam/data/frame.h
@@ -9,7 +9,7 @@
 #include <vector>
 #include <atomic>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 #include <Eigen/Core>
 
 #ifdef USE_DBOW2

--- a/src/openvslam/data/keyframe.cc
+++ b/src/openvslam/data/keyframe.cc
@@ -10,6 +10,8 @@
 #include "openvslam/feature/orb_params.h"
 #include "openvslam/util/converter.h"
 
+#include <nlohmann/json.hpp>
+
 namespace openvslam {
 namespace data {
 

--- a/src/openvslam/data/keyframe.h
+++ b/src/openvslam/data/keyframe.h
@@ -11,7 +11,7 @@
 #include <atomic>
 
 #include <g2o/types/sba/types_six_dof_expmap.h>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #ifdef USE_DBOW2
 #include <DBoW2/BowVector.h>

--- a/src/openvslam/data/landmark.cc
+++ b/src/openvslam/data/landmark.cc
@@ -4,6 +4,8 @@
 #include "openvslam/data/map_database.h"
 #include "openvslam/match/base.h"
 
+#include <nlohmann/json.hpp>
+
 namespace openvslam {
 namespace data {
 

--- a/src/openvslam/data/landmark.h
+++ b/src/openvslam/data/landmark.h
@@ -8,7 +8,7 @@
 #include <atomic>
 
 #include <opencv2/core/core.hpp>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace openvslam {
 namespace data {

--- a/src/openvslam/data/map_database.cc
+++ b/src/openvslam/data/map_database.cc
@@ -8,6 +8,7 @@
 #include "openvslam/util/converter.h"
 
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
 namespace openvslam {
 namespace data {

--- a/src/openvslam/data/map_database.h
+++ b/src/openvslam/data/map_database.h
@@ -8,7 +8,7 @@
 #include <vector>
 #include <unordered_map>
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 namespace openvslam {
 

--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -37,7 +37,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "openvslam/feature/orb_point_pairs.h"
 #include "openvslam/util/trigonometric.h"
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/features2d.hpp>
 
 #ifdef USE_SSE_ORB
 #ifdef _MSC_VER

--- a/src/openvslam/initialize/bearing_vector.h
+++ b/src/openvslam/initialize/bearing_vector.h
@@ -4,7 +4,7 @@
 #include "openvslam/type.h"
 #include "openvslam/initialize/base.h"
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 

--- a/src/openvslam/initialize/perspective.h
+++ b/src/openvslam/initialize/perspective.h
@@ -4,7 +4,7 @@
 #include "openvslam/type.h"
 #include "openvslam/initialize/base.h"
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 

--- a/src/openvslam/match/base.h
+++ b/src/openvslam/match/base.h
@@ -5,7 +5,7 @@
 #include <algorithm>
 #include <numeric>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace match {

--- a/src/openvslam/publish/frame_publisher.cc
+++ b/src/openvslam/publish/frame_publisher.cc
@@ -3,6 +3,7 @@
 #include "openvslam/publish/frame_publisher.h"
 
 #include <spdlog/spdlog.h>
+#include "opencv2/imgproc.hpp"
 
 namespace openvslam {
 namespace publish {

--- a/src/openvslam/publish/frame_publisher.cc
+++ b/src/openvslam/publish/frame_publisher.cc
@@ -3,7 +3,7 @@
 #include "openvslam/publish/frame_publisher.h"
 
 #include <spdlog/spdlog.h>
-#include "opencv2/imgproc.hpp"
+#include <opencv2/imgproc.hpp>
 
 namespace openvslam {
 namespace publish {

--- a/src/openvslam/solve/common.h
+++ b/src/openvslam/solve/common.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace solve {

--- a/src/openvslam/solve/essential_solver.h
+++ b/src/openvslam/solve/essential_solver.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace solve {

--- a/src/openvslam/solve/fundamental_solver.h
+++ b/src/openvslam/solve/fundamental_solver.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace solve {

--- a/src/openvslam/solve/homography_solver.h
+++ b/src/openvslam/solve/homography_solver.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace solve {

--- a/src/openvslam/solve/sim3_solver.h
+++ b/src/openvslam/solve/sim3_solver.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace solve {

--- a/src/openvslam/solve/triangulator.h
+++ b/src/openvslam/solve/triangulator.h
@@ -4,7 +4,7 @@
 #include "openvslam/type.h"
 
 #include <Eigen/SVD>
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace solve {

--- a/src/openvslam/util/image_converter.cc
+++ b/src/openvslam/util/image_converter.cc
@@ -1,6 +1,6 @@
 #include "openvslam/util/image_converter.h"
 
-#include "opencv2/imgproc.hpp"
+#include <opencv2/imgproc.hpp>
 
 namespace openvslam {
 namespace util {

--- a/src/openvslam/util/image_converter.cc
+++ b/src/openvslam/util/image_converter.cc
@@ -1,5 +1,7 @@
 #include "openvslam/util/image_converter.h"
 
+#include "opencv2/imgproc.hpp"
+
 namespace openvslam {
 namespace util {
 

--- a/src/openvslam/util/image_converter.h
+++ b/src/openvslam/util/image_converter.h
@@ -3,7 +3,7 @@
 
 #include "openvslam/camera/base.h"
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 namespace util {

--- a/src/openvslam/util/stereo_rectifier.cc
+++ b/src/openvslam/util/stereo_rectifier.cc
@@ -3,6 +3,7 @@
 #include "openvslam/util/stereo_rectifier.h"
 
 #include <spdlog/spdlog.h>
+#include "opencv2/imgproc.hpp"
 
 namespace openvslam {
 namespace util {

--- a/src/openvslam/util/stereo_rectifier.cc
+++ b/src/openvslam/util/stereo_rectifier.cc
@@ -3,7 +3,7 @@
 #include "openvslam/util/stereo_rectifier.h"
 
 #include <spdlog/spdlog.h>
-#include "opencv2/imgproc.hpp"
+#include <opencv2/imgproc.hpp>
 
 namespace openvslam {
 namespace util {

--- a/src/pangolin_viewer/viewer.cc
+++ b/src/pangolin_viewer/viewer.cc
@@ -7,6 +7,8 @@
 #include "openvslam/publish/frame_publisher.h"
 #include "openvslam/publish/map_publisher.h"
 
+#include "opencv2/highgui.hpp"
+
 namespace pangolin_viewer {
 
 viewer::viewer(const std::shared_ptr<openvslam::config>& cfg, openvslam::system* system,

--- a/src/pangolin_viewer/viewer.cc
+++ b/src/pangolin_viewer/viewer.cc
@@ -7,7 +7,7 @@
 #include "openvslam/publish/frame_publisher.h"
 #include "openvslam/publish/map_publisher.h"
 
-#include "opencv2/highgui.hpp"
+#include <opencv2/highgui.hpp>
 
 namespace pangolin_viewer {
 

--- a/src/socket_publisher/data_serializer.cc
+++ b/src/socket_publisher/data_serializer.cc
@@ -5,6 +5,10 @@
 #include "openvslam/publish/frame_publisher.h"
 #include "openvslam/publish/map_publisher.h"
 
+#include <forward_list>
+
+#include <opencv2/imgcodecs.hpp>
+
 // map_segment.pb.h will be generated into build/src/socket_publisher/ when make
 #include "map_segment.pb.h"
 

--- a/src/socket_publisher/data_serializer.h
+++ b/src/socket_publisher/data_serializer.h
@@ -7,7 +7,7 @@
 
 #include <Eigen/Core>
 #include <sio_client.h>
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
 
 namespace openvslam {
 

--- a/test/openvslam/feature/orb_extractor.cc
+++ b/test/openvslam/feature/orb_extractor.cc
@@ -1,6 +1,10 @@
 #include "openvslam/feature/orb_extractor.h"
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
This PR does not change functionality.
In fact, only `#include` lines are changed.

`nlohmann/json.hpp` is replaced by `nlohmann/json_fwd.hpp`, which only forward-declares the necessary structured.
In implementation files, the full `nlohmann/json.hpp` is included as needed.

`opencv2/opencv.hpp` is replaced with more specific imports.

Together these changes improve build time by roughly 15% according to my (rudimentary) measurements.