### PR TITLE
Modify image_bounds for super wide fisheye camera to fix issue #83

### DIFF
--- a/src/openvslam/camera/fisheye.cc
+++ b/src/openvslam/camera/fisheye.cc
@@ -80,9 +80,9 @@ image_bounds fisheye::compute_image_bounds() const {
 
         // fix for issue #83
         // check if fov is super wide (four corners are out of view) based on upper-left corner
-        double pwx = (0.0 - cx_) / fx_;
-        double pwy = (0.0 - cy_) / fy_;
-        double theta_d = sqrt(pwx * pwx + pwy * pwy);
+        const double pwx = (0.0 - cx_) / fx_;
+        const double pwy = (0.0 - cy_) / fy_;
+        const double theta_d = sqrt(pwx * pwx + pwy * pwy);
 
         if (theta_d > M_PI_2) {
             // fov is super wide (four corners are out of view)

--- a/src/openvslam/camera/fisheye.cc
+++ b/src/openvslam/camera/fisheye.cc
@@ -78,19 +78,68 @@ image_bounds fisheye::compute_image_bounds() const {
     else {
         // distortion exists
 
-        // corner coordinates: (x, y) = (col, row)
-        const std::vector<cv::KeyPoint> corners{cv::KeyPoint(0.0, 0.0, 1.0),      // left top
-                                                cv::KeyPoint(cols_, 0.0, 1.0),    // right top
-                                                cv::KeyPoint(0.0, rows_, 1.0),    // left bottom
-                                                cv::KeyPoint(cols_, rows_, 1.0)}; // right bottom
+        // fix for issue #83
+        // check if fov is super wide (four corners are out of view) based on upper-left corner
+        double pwx = (0.0 - cx_) / fx_;
+        double pwy = (0.0 - cy_) / fy_;
+        double theta_d = sqrt(pwx * pwx + pwy * pwy);
 
-        std::vector<cv::KeyPoint> undist_corners;
-        undistort_keypoints(corners, undist_corners);
+        if (theta_d > M_PI_2) {
+            // fov is super wide (four corners are out of view)
 
-        return image_bounds{std::min(undist_corners.at(0).pt.x, undist_corners.at(2).pt.x),
-                            std::max(undist_corners.at(1).pt.x, undist_corners.at(3).pt.x),
-                            std::min(undist_corners.at(0).pt.y, undist_corners.at(1).pt.y),
-                            std::max(undist_corners.at(2).pt.y, undist_corners.at(3).pt.y)};
+            // corner coordinates: (x, y) = (col, row)
+            const std::vector<cv::KeyPoint> corners{cv::KeyPoint(cx_, 0.0, 1.0),    // top: min_y
+                                                    cv::KeyPoint(cols_, cy_, 1.0),  // right: max_x
+                                                    cv::KeyPoint(0.0, cy_, 1.0),    // left: min_x
+                                                    cv::KeyPoint(cx_, rows_, 1.0)}; // down: max_y
+
+            std::vector<cv::KeyPoint> undist_corners;
+            undistort_keypoints(corners, undist_corners);
+
+            // deal with over 180 deg fov
+            // some points over 180 deg are projected on the opposite side (plus or minus are different)
+            double INF_VALUE = 1000000;
+            if (undist_corners.at(0).pt.y > rows_ / 2.0)
+                undist_corners.at(0).pt.y = -INF_VALUE;
+            if (undist_corners.at(1).pt.x < cols_ / 2.0)
+                undist_corners.at(1).pt.x = INF_VALUE;
+            if (undist_corners.at(2).pt.x > cols_ / 2.0)
+                undist_corners.at(2).pt.x = -INF_VALUE;
+            if (undist_corners.at(3).pt.y < rows_ / 2.0)
+                undist_corners.at(3).pt.y = INF_VALUE;
+
+            // limit image_bounds by incident angle
+            // when deg_thr = 5, only incident angle < 85 deg is accepted
+            const float deg_thr = 5;
+            const float dist_thr_x = fx_ / std::tan(deg_thr * M_PI / 180.0);
+            const float dist_thr_y = fy_ / std::tan(deg_thr * M_PI / 180.0);
+            float num_y_min_ = -dist_thr_y + cy_;
+            float num_y_max_ = dist_thr_y + cy_;
+            float num_x_min_ = -dist_thr_x + cx_;
+            float num_x_max_ = dist_thr_x + cx_;
+
+            return image_bounds{std::max(undist_corners.at(2).pt.x, num_x_min_),
+                                std::min(undist_corners.at(1).pt.x, num_x_max_),
+                                std::max(undist_corners.at(0).pt.y, num_y_min_),
+                                std::min(undist_corners.at(3).pt.y, num_y_max_)};
+        }
+        else {
+            // fov is normal (four corners are inside of view)
+
+            // corner coordinates: (x, y) = (col, row)
+            const std::vector<cv::KeyPoint> corners{cv::KeyPoint(0.0, 0.0, 1.0),      // left top
+                                                    cv::KeyPoint(cols_, 0.0, 1.0),    // right top
+                                                    cv::KeyPoint(0.0, rows_, 1.0),    // left bottom
+                                                    cv::KeyPoint(cols_, rows_, 1.0)}; // right bottom
+
+            std::vector<cv::KeyPoint> undist_corners;
+            undistort_keypoints(corners, undist_corners);
+
+            return image_bounds{std::min(undist_corners.at(0).pt.x, undist_corners.at(2).pt.x),
+                                std::max(undist_corners.at(1).pt.x, undist_corners.at(3).pt.x),
+                                std::min(undist_corners.at(0).pt.y, undist_corners.at(1).pt.y),
+                                std::max(undist_corners.at(2).pt.y, undist_corners.at(3).pt.y)};
+        }
     }
 }
 


### PR DESCRIPTION
This is the fix for #83 when you use a super-wide FoV fisheye camera. 
In original source code, image_bounds are calculated by four corners in images, but the four corners may be outside of the view when a super-wide FoV fisheye camera is used.

In the modified source code, I checked if the camera has a super-wide FoV or not (the four corners are outside of the view or not) by calculating `theta_d`  from [here](https://github.com/opencv/opencv/blob/a165f5557974c7ba32e5d6c966ec053d2bf932cc/modules/calib3d/src/fisheye.cpp#L382). If `theta_d>M_PI/2`, the camera has a super-wide FoV.

Beside, image_bounds are limited by the incident angle for a super-wide FoV fisheye camera since OpenCV fisheye camera model can't handle more than 180 deg FoV.  
