### PR TITLE
Support for TUM Visual-Inertial Dataset

### DIFF
--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -57,7 +57,7 @@ void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
     std::thread thread([&]() {
         for (unsigned int i = 0; i < frames.size(); ++i) {
             const auto& frame = frames.at(i);
-            const auto img = cv::imread(frame.left_img_path_, cv::IMREAD_UNCHANGED);
+            const auto img = cv::imread(frame.left_img_path_, cv::IMREAD_GRAYSCALE);
 
             const auto tp_1 = std::chrono::steady_clock::now();
 
@@ -172,8 +172,8 @@ void stereo_tracking(const std::shared_ptr<openvslam::config>& cfg,
     std::thread thread([&]() {
         for (unsigned int i = 0; i < frames.size(); ++i) {
             const auto& frame = frames.at(i);
-            const auto left_img = cv::imread(frame.left_img_path_, cv::IMREAD_UNCHANGED);
-            const auto right_img = cv::imread(frame.right_img_path_, cv::IMREAD_UNCHANGED);
+            const auto left_img = cv::imread(frame.left_img_path_, cv::IMREAD_GRAYSCALE);
+            const auto right_img = cv::imread(frame.right_img_path_, cv::IMREAD_GRAYSCALE);
 
             if (left_img.empty() || right_img.empty()) {
                 continue;

--- a/example/run_euroc_slam.cc
+++ b/example/run_euroc_slam.cc
@@ -9,6 +9,7 @@
 #include "openvslam/system.h"
 #include "openvslam/config.h"
 #include "openvslam/util/stereo_rectifier.h"
+#include "openvslam/util/image_converter.h"
 
 #include <iostream>
 #include <algorithm>
@@ -33,7 +34,7 @@
 void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
                    const std::string& vocab_file_path, const std::string& sequence_dir_path,
                    const unsigned int frame_skip, const bool no_sleep, const bool auto_term,
-                   const bool eval_log, const std::string& map_db_path) {
+                   const bool eval_log, const std::string& map_db_path, const bool equal_hist) {
     const euroc_sequence sequence(sequence_dir_path);
     const auto frames = sequence.get_frames();
 
@@ -57,7 +58,14 @@ void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
     std::thread thread([&]() {
         for (unsigned int i = 0; i < frames.size(); ++i) {
             const auto& frame = frames.at(i);
-            const auto img = cv::imread(frame.left_img_path_, cv::IMREAD_GRAYSCALE);
+            cv::Mat img;
+            if (equal_hist) {
+                img = cv::imread(frame.left_img_path_, cv::IMREAD_UNCHANGED);
+                openvslam::util::equalize_histogram(img);
+            }
+            else {
+                img = cv::imread(frame.left_img_path_, cv::IMREAD_GRAYSCALE);
+            }
 
             const auto tp_1 = std::chrono::steady_clock::now();
 
@@ -144,7 +152,7 @@ void mono_tracking(const std::shared_ptr<openvslam::config>& cfg,
 void stereo_tracking(const std::shared_ptr<openvslam::config>& cfg,
                      const std::string& vocab_file_path, const std::string& sequence_dir_path,
                      const unsigned int frame_skip, const bool no_sleep, const bool auto_term,
-                     const bool eval_log, const std::string& map_db_path) {
+                     const bool eval_log, const std::string& map_db_path, const bool equal_hist) {
     const euroc_sequence sequence(sequence_dir_path);
     const auto frames = sequence.get_frames();
 
@@ -172,8 +180,17 @@ void stereo_tracking(const std::shared_ptr<openvslam::config>& cfg,
     std::thread thread([&]() {
         for (unsigned int i = 0; i < frames.size(); ++i) {
             const auto& frame = frames.at(i);
-            const auto left_img = cv::imread(frame.left_img_path_, cv::IMREAD_GRAYSCALE);
-            const auto right_img = cv::imread(frame.right_img_path_, cv::IMREAD_GRAYSCALE);
+            cv::Mat left_img, right_img;
+            if (equal_hist) {
+                left_img = cv::imread(frame.left_img_path_, cv::IMREAD_UNCHANGED);
+                right_img = cv::imread(frame.right_img_path_, cv::IMREAD_UNCHANGED);
+                openvslam::util::equalize_histogram(left_img);
+                openvslam::util::equalize_histogram(right_img);
+            }
+            else {
+                left_img = cv::imread(frame.left_img_path_, cv::IMREAD_GRAYSCALE);
+                right_img = cv::imread(frame.right_img_path_, cv::IMREAD_GRAYSCALE);
+            }
 
             if (left_img.empty() || right_img.empty()) {
                 continue;
@@ -281,6 +298,8 @@ int main(int argc, char* argv[]) {
     auto debug_mode = op.add<popl::Switch>("", "debug", "debug mode");
     auto eval_log = op.add<popl::Switch>("", "eval-log", "store trajectory and tracking times for evaluation");
     auto map_db_path = op.add<popl::Value<std::string>>("p", "map-db", "store a map database at this path after SLAM", "");
+    auto equal_hist = op.add<popl::Switch>("", "equal-hist", "apply histogram equalization");
+
     try {
         op.parse(argc, argv);
     }
@@ -330,12 +349,12 @@ int main(int argc, char* argv[]) {
     if (cfg->camera_->setup_type_ == openvslam::camera::setup_type_t::Monocular) {
         mono_tracking(cfg, vocab_file_path->value(), data_dir_path->value(),
                       frame_skip->value(), no_sleep->is_set(), auto_term->is_set(),
-                      eval_log->is_set(), map_db_path->value());
+                      eval_log->is_set(), map_db_path->value(), equal_hist->is_set());
     }
     else if (cfg->camera_->setup_type_ == openvslam::camera::setup_type_t::Stereo) {
         stereo_tracking(cfg, vocab_file_path->value(), data_dir_path->value(),
                         frame_skip->value(), no_sleep->is_set(), auto_term->is_set(),
-                        eval_log->is_set(), map_db_path->value());
+                        eval_log->is_set(), map_db_path->value(), equal_hist->is_set());
     }
     else {
         throw std::runtime_error("Invalid setup type: " + cfg->camera_->get_setup_type_string());

--- a/example/tum_vi/TUM_VI_mono.yaml
+++ b/example/tum_vi/TUM_VI_mono.yaml
@@ -1,0 +1,43 @@
+# TUM VI monocular model
+# https://vision.in.tum.de/data/datasets/visual-inertial-dataset#geometric_calibration
+# pinhole (512x512)
+
+#==============#
+# Camera Model #
+#==============#
+
+Camera.name: "TUM VI monocular"
+Camera.setup: "monocular"
+Camera.model: "fisheye"
+
+Camera.fx: 190.97847715128717
+Camera.fy: 190.9733070521226
+Camera.cx: 254.93170605935475
+Camera.cy: 256.8974428996504
+
+Camera.k1: 0.0034823894022493434
+Camera.k2: 0.0007150348452162257
+Camera.k3: -0.0020532361418706202
+Camera.k4: 0.00020293673591811182
+
+Camera.fps: 20
+Camera.cols: 512
+Camera.rows: 512
+
+Camera.color_order: "Gray"
+
+#================#
+# ORB Parameters #
+#================#
+
+Feature.max_num_keypoints: 1000
+Feature.scale_factor: 1.2
+Feature.num_levels: 8
+Feature.ini_fast_threshold: 20
+Feature.min_fast_threshold: 7
+
+#========================#
+# Initializer Parameters #
+#========================#
+
+Initializer.scaling_factor: 2.0

--- a/example/tum_vi/TUM_VI_stereo.yaml
+++ b/example/tum_vi/TUM_VI_stereo.yaml
@@ -1,0 +1,70 @@
+# TUM VI stereo rectify model
+# https://vision.in.tum.de/data/datasets/visual-inertial-dataset#geometric_calibration
+# pinhole (512x512)
+
+#==============#
+# Camera Model #
+#==============#
+
+Camera.name: "TUM VI stereo"
+Camera.setup: "stereo"
+Camera.model: "perspective"
+
+# new "rectified" matrices is the first three cols of the projection matrix which is calculated with cv::stereoRectify()
+# e.g. fx = P1[0][0] or P2[0][0], cx = P1[0][2] or P2[0][2]
+#      fy = P1[1][1] or P2[1][1], cy = P1[1][2] or P2[1][2]
+
+Camera.fx: 61.75453410721205
+Camera.fy: 61.75453410721205
+Camera.cx: 240.22941720459062
+Camera.cy: 255.73235402091632
+
+# there is no distortion after stereo rectification
+
+Camera.k1: 0.0
+Camera.k2: 0.0
+Camera.p1: 0.0
+Camera.p2: 0.0
+Camera.k3: 0.0
+
+# focal_x_baseline is -P2[0][3] which is calculated with cv::stereoRectify()
+
+Camera.fps: 20
+Camera.cols: 512
+Camera.rows: 512
+Camera.focal_x_baseline: 6.242596912726197
+
+#======================#
+# Stereo Rectification #
+#======================#
+
+# original intrinsic parameters (K, D) and stereo-recitification parameters (R)
+# matrices (K, R) are written in row-major order
+# StereoRectifier.model is camera model before rectification
+
+StereoRectifier.model: "fisheye"
+StereoRectifier.K_left: [190.97847715128717, 0.0, 254.93170605935475, 0.0, 190.9733070521226, 256.8974428996504, 0.0, 0.0, 1.0]
+StereoRectifier.D_left: [0.0034823894022493434, 0.0007150348452162257, -0.0020532361418706202, 0.00020293673591811182]
+StereoRectifier.R_left: [0.9997641946925044, 0.01925271884177015, 0.010044293307535757, -0.01901185247371587, 0.9995418997803748, -0.02354867403818772, -0.010493068014919314, 0.02335216051329943, 0.99967223234568]
+StereoRectifier.K_right: [190.44236969414825, 0.0, 252.59949716835982, 0.0, 190.4344384721956, 254.91723064636983, 0.0, 0.0, 1.0]
+StereoRectifier.D_right: [0.0034003170790442797, 0.001766278153469831, -0.00266312569781606, 0.0003299517423931039]
+StereoRectifier.R_right: [0.9997411981023351, 0.01955199401713946, 0.011629976219300583, -0.019819377433695273, 0.9995311538731381, 0.02333805294307984, -0.011168218078479885, -0.023562511898925578, 0.9996599816627474]
+
+Camera.color_order: "Gray"
+
+#================#
+# ORB Parameters #
+#================#
+
+Feature.max_num_keypoints: 1000
+Feature.scale_factor: 1.2
+Feature.num_levels: 8
+Feature.ini_fast_threshold: 20
+Feature.min_fast_threshold: 7
+
+#========================#
+# Initializer Parameters #
+#========================#
+
+Initializer.num_min_triangulated_pts: 100
+

--- a/src/openvslam/util/image_converter.cc
+++ b/src/openvslam/util/image_converter.cc
@@ -47,15 +47,15 @@ void equalize_histogram(cv::Mat& img) {
     if (img.type() == CV_16UC1) {
         std::vector<unsigned short> vec(img.begin<unsigned short>(), img.end<unsigned short>());
         std::sort(vec.begin(), vec.end());
-        auto l = vec.at(static_cast<unsigned int>(0.05 * vec.size()));
-        auto h = vec.at(static_cast<unsigned int>(0.95 * vec.size()));
+        const auto l = vec.at(static_cast<unsigned int>(0.05 * vec.size()));
+        const auto h = vec.at(static_cast<unsigned int>(0.95 * vec.size()));
         img.convertTo(img, CV_8UC1, 255.0 / (h - l), -255.0 * l / (h - l)); // 255*(img-l)/(h-l)
     }
     else if (img.type() == CV_8UC1) {
         std::vector<unsigned char> vec(img.begin<unsigned char>(), img.end<unsigned char>());
         std::sort(vec.begin(), vec.end());
-        auto l = vec.at(static_cast<unsigned int>(0.05 * vec.size()));
-        auto h = vec.at(static_cast<unsigned int>(0.95 * vec.size()));
+        const auto l = vec.at(static_cast<unsigned int>(0.05 * vec.size()));
+        const auto h = vec.at(static_cast<unsigned int>(0.95 * vec.size()));
         img.convertTo(img, CV_8UC1, 255.0 / (h - l), -255.0 * l / (h - l)); // 255*(img-l)/(h-l)
     }
 }

--- a/src/openvslam/util/image_converter.cc
+++ b/src/openvslam/util/image_converter.cc
@@ -42,5 +42,23 @@ void convert_to_true_depth(cv::Mat& img, const double depthmap_factor) {
     img.convertTo(img, CV_32F, 1.0 / depthmap_factor);
 }
 
+void equalize_histogram(cv::Mat& img) {
+    assert(img.type() == CV_8UC1 || img.type() == CV_16UC1);
+    if (img.type() == CV_16UC1) {
+        std::vector<unsigned short> vec(img.begin<unsigned short>(), img.end<unsigned short>());
+        std::sort(vec.begin(), vec.end());
+        auto l = vec.at(static_cast<unsigned int>(0.05 * vec.size()));
+        auto h = vec.at(static_cast<unsigned int>(0.95 * vec.size()));
+        img.convertTo(img, CV_8UC1, 255.0 / (h - l), -255.0 * l / (h - l)); // 255*(img-l)/(h-l)
+    }
+    else if (img.type() == CV_8UC1) {
+        std::vector<unsigned char> vec(img.begin<unsigned char>(), img.end<unsigned char>());
+        std::sort(vec.begin(), vec.end());
+        auto l = vec.at(static_cast<unsigned int>(0.05 * vec.size()));
+        auto h = vec.at(static_cast<unsigned int>(0.95 * vec.size()));
+        img.convertTo(img, CV_8UC1, 255.0 / (h - l), -255.0 * l / (h - l)); // 255*(img-l)/(h-l)
+    }
+}
+
 } // namespace util
 } // namespace openvslam

--- a/src/openvslam/util/image_converter.h
+++ b/src/openvslam/util/image_converter.h
@@ -12,6 +12,8 @@ void convert_to_grayscale(cv::Mat& img, const camera::color_order_t in_color_ord
 
 void convert_to_true_depth(cv::Mat& img, const double depthmap_factor);
 
+void equalize_histogram(cv::Mat& img);
+
 } // namespace util
 } // namespace openvslam
 

--- a/src/openvslam/util/stereo_rectifier.h
+++ b/src/openvslam/util/stereo_rectifier.h
@@ -28,8 +28,10 @@ private:
     //! Parse std::vector as cv::Mat
     static cv::Mat parse_vector_as_mat(const cv::Size& shape, const std::vector<double>& vec);
 
-    //! camera model type
+    //! camera model type before rectification
     const camera::model_type_t model_type_;
+    //! Load model type before rectification from YAML
+    static camera::model_type_t load_model_type(const YAML::Node& yaml_node);
 
     //! undistortion map for x-axis in left image
     cv::Mat undist_map_x_l_;


### PR DESCRIPTION
Hi! Thank you for the wonderful project! 
I modified the source code to run on [TUM Visual-Inertial Dataset](https://vision.in.tum.de/data/datasets/visual-inertial-dataset) by `run_euroc_slam`.   You need to merge #165 first since images from TUM VI are captured by superwide fisheye cameras (`min_y > max_y` problems mentioned in #83 ). 

I have questions:
I'd like to add calibration files that I'm using for TUM VI. But, where should I add them? `run_euroc_slam` is used to run on TUM VI so inside `openvslam/example/euroc` is fine? or should I create an additional folder `openvslam/example/tum_vi`?
FYI, I used the following script to generate the calibration YAML files.
https://nbviewer.jupyter.org/gist/matsuren/6c00e1b6e006df9ef87c3271316cd5f9

Also, let me know if you want me to add some instruction about TUM VI in the documents.
