### PR TITLE
Fix bad_alloc crash during global BA

### DIFF
--- a/src/openvslam/optimize/global_bundle_adjuster.cc
+++ b/src/openvslam/optimize/global_bundle_adjuster.cc
@@ -69,7 +69,7 @@ void global_bundle_adjuster::optimize(const unsigned int lead_keyfrm_id_in_globa
     // reprojection edgeのcontainer
     using reproj_edge_wrapper = g2o::se3::reproj_edge_wrapper<data::keyframe>;
     std::vector<reproj_edge_wrapper> reproj_edge_wraps;
-    reproj_edge_wraps.reserve(keyfrms.size() * lms.size());
+    reproj_edge_wraps.reserve(10 * lms.size());
 
     // 有意水準5%のカイ2乗値
     // 自由度n=2


### PR DESCRIPTION
In the global bundle adjuster, change the initial estimate for the number of edges in the graph from `keyfrms.size() * lms.size()` to `10 * lms.size()`. The previous was a large overestimation, causing crashes due to failed memory allocation when operating on larger maps.

The new value should be a generous estimation (assuming that every landmark is included in the BA and it is observed 10 times), while keeping memory consumption acceptable.

Resolves #188 