### PR TITLE
Remove unused GPL-licensed SPQR dependency

### DIFF
--- a/cmake/FindSuiteSparse.cmake
+++ b/cmake/FindSuiteSparse.cmake
@@ -86,11 +86,6 @@
 # CHOLMOD_INCLUDE_DIR
 # CHOLMOD_LIBRARY
 #
-# == Multifrontal Sparse QR (SuiteSparseQR)
-# SUITESPARSEQR_FOUND
-# SUITESPARSEQR_INCLUDE_DIR
-# SUITESPARSEQR_LIBRARY
-#
 # == Common configuration for all but CSparse (SuiteSparse version >= 4).
 # SUITESPARSE_CONFIG_FOUND
 # SUITESPARSE_CONFIG_INCLUDE_DIR
@@ -338,75 +333,6 @@ else (EXISTS ${CHOLMOD_INCLUDE_DIR})
     set(CHOLMOD_FOUND FALSE)
 endif (EXISTS ${CHOLMOD_INCLUDE_DIR})
 mark_as_advanced(CHOLMOD_INCLUDE_DIR)
-
-# SuiteSparseQR.
-set(SUITESPARSEQR_FOUND TRUE)
-list(APPEND SUITESPARSE_FOUND_REQUIRED_VARS SUITESPARSEQR_FOUND)
-find_library(SUITESPARSEQR_LIBRARY NAMES spqr
-        PATHS ${SUITESPARSE_CHECK_LIBRARY_DIRS})
-if (EXISTS ${SUITESPARSEQR_LIBRARY})
-    message(STATUS "Found SuiteSparseQR library: ${SUITESPARSEQR_LIBRARY}")
-else (EXISTS ${SUITESPARSEQR_LIBRARY})
-    suitesparse_report_not_found(
-            "Did not find SuiteSparseQR library (required SuiteSparse component).")
-    set(SUITESPARSEQR_FOUND FALSE)
-endif (EXISTS ${SUITESPARSEQR_LIBRARY})
-mark_as_advanced(SUITESPARSEQR_LIBRARY)
-
-find_path(SUITESPARSEQR_INCLUDE_DIR NAMES SuiteSparseQR.hpp
-        PATHS ${SUITESPARSE_CHECK_INCLUDE_DIRS})
-if (EXISTS ${SUITESPARSEQR_INCLUDE_DIR})
-    message(STATUS "Found SuiteSparseQR header in: ${SUITESPARSEQR_INCLUDE_DIR}")
-else (EXISTS ${SUITESPARSEQR_INCLUDE_DIR})
-    suitesparse_report_not_found(
-            "Did not find SUITESPARSEQR header (required SuiteSparse component).")
-    set(SUITESPARSEQR_FOUND FALSE)
-endif (EXISTS ${SUITESPARSEQR_INCLUDE_DIR})
-mark_as_advanced(SUITESPARSEQR_INCLUDE_DIR)
-
-if (SUITESPARSEQR_FOUND)
-    # SuiteSparseQR may be compiled with Intel Threading Building Blocks,
-    # we assume that if TBB is installed, SuiteSparseQR was compiled with
-    # support for it, this will do no harm if it wasn't.
-    set(TBB_FOUND TRUE)
-    find_library(TBB_LIBRARIES NAMES tbb
-            PATHS ${SUITESPARSE_CHECK_LIBRARY_DIRS})
-    if (EXISTS ${TBB_LIBRARIES})
-        message(STATUS "Found Intel Thread Building Blocks (TBB) library: "
-                "${TBB_LIBRARIES}, assuming SuiteSparseQR was compiled with TBB.")
-    else (EXISTS ${TBB_LIBRARIES})
-        message(STATUS "Did not find Intel TBB library, assuming SuiteSparseQR was "
-                "not compiled with TBB.")
-        set(TBB_FOUND FALSE)
-    endif (EXISTS ${TBB_LIBRARIES})
-    mark_as_advanced(TBB_LIBRARIES)
-
-    if (TBB_FOUND)
-        find_library(TBB_MALLOC_LIB NAMES tbbmalloc
-                PATHS ${SUITESPARSE_CHECK_LIBRARY_DIRS})
-        if (EXISTS ${TBB_MALLOC_LIB})
-            message(STATUS "Found Intel Thread Building Blocks (TBB) Malloc library: "
-                    "${TBB_MALLOC_LIB}")
-            # Append TBB malloc library to TBB libraries list whilst retaining
-            # any CMake generated help string (cache variable).
-            list(APPEND TBB_LIBRARIES ${TBB_MALLOC_LIB})
-            get_property(HELP_STRING CACHE TBB_LIBRARIES PROPERTY HELPSTRING)
-            set(TBB_LIBRARIES "${TBB_LIBRARIES}" CACHE STRING "${HELP_STRING}")
-
-            # Add the TBB libraries to the SuiteSparseQR libraries (the only
-            # libraries to optionally depend on TBB).
-            list(APPEND SUITESPARSEQR_LIBRARY ${TBB_LIBRARIES})
-
-        else (EXISTS ${TBB_MALLOC_LIB})
-            # If we cannot find all required TBB components do not include it as
-            # a dependency.
-            message(STATUS "Did not find Intel Thread Building Blocks (TBB) Malloc "
-                    "Library, discarding TBB as a dependency.")
-            set(TBB_FOUND FALSE)
-        endif (EXISTS ${TBB_MALLOC_LIB})
-        mark_as_advanced(TBB_MALLOC_LIB)
-    endif (TBB_FOUND)
-endif(SUITESPARSEQR_FOUND)
 
 # UFconfig / SuiteSparse_config.
 #


### PR DESCRIPTION
The SuiteSparse components are licensed under different terms. SPQR happens to be [GPL-licensed](https://github.com/DrTimothyAldenDavis/SuiteSparse/blob/79f25b523ae0fd81abe1ffb0efd9005f2e6eef33/LICENSE.txt#L742-L750) (not LGPL), and linking to that library...
```
▹ ldd lib/libopenvslam.so | grep spqr
	libspqr.so.2 => /usr/lib/x86_64-linux-gnu/libspqr.so.2 (0x00007f3561fe6000)
```
... essentially makes all OpenVSLAM code and everything potentially linking to it GPL-licensed too, which, I assume, is not the intention. This PR simply removes that unused dependency (which seems to be just accidentally copied from Ceres CMake files anyway)