### PR TITLE
Allow to create `openvslam::config` from `YAML::Node`

### DIFF
--- a/src/openvslam/config.cc
+++ b/src/openvslam/config.cc
@@ -11,7 +11,10 @@
 namespace openvslam {
 
 config::config(const std::string& config_file_path)
-    : config_file_path_(config_file_path), yaml_node_(YAML::LoadFile(config_file_path)) {
+    : config(YAML::LoadFile(config_file_path), config_file_path) {}
+
+config::config(const YAML::Node& yaml_node, const std::string& config_file_path)
+    : config_file_path_(config_file_path), yaml_node_(yaml_node) {
     spdlog::debug("CONSTRUCT: config");
 
     spdlog::info("config file loaded: {}", config_file_path_);

--- a/src/openvslam/config.h
+++ b/src/openvslam/config.h
@@ -12,6 +12,7 @@ class config {
 public:
     //! Constructor
     explicit config(const std::string& config_file_path);
+    explicit config(const YAML::Node& yaml_node, const std::string& config_file_path = "");
 
     //! Destructor
     ~config();


### PR DESCRIPTION
Hi! This is a possible suggestion to solve #198.

It implements a second constructor for `openvslam::config`, allowing to create a config object directly from a YAML node.

Resolves #198 