### PR TITLE
Fix CMake configuration for g2o

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,8 @@ before_install:
         -DBUILD_SHARED_LIBS=ON \
         -DBUILD_UNITTESTS=OFF \
         -DBUILD_WITH_MARCH_NATIVE=ON \
+        -DG2O_BUILD_EXAMPLES=OFF \
+        -DG2O_BUILD_APPS=OFF \
         -DG2O_USE_CHOLMOD=OFF \
         -DG2O_USE_CSPARSE=ON \
         -DG2O_USE_OPENGL=OFF \


### PR DESCRIPTION
Disabled builds of apps and examples which are contained in g2o since Travis-CI fails due to lack of dependencies for them.