### PR TITLE
Add EIGEN_MAKE_ALIGNED_OPERATOR_NEW to fisheye.h

### DIFF
--- a/src/openvslam/camera/fisheye.h
+++ b/src/openvslam/camera/fisheye.h
@@ -10,6 +10,8 @@ namespace camera {
 
 class fisheye final : public base {
 public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     fisheye(const std::string& name, const setup_type_t& setup_type, const color_order_t& color_order,
             const unsigned int cols, const unsigned int rows, const double fps,
             const double fx, const double fy, const double cx, const double cy,

--- a/src/openvslam/camera/perspective.h
+++ b/src/openvslam/camera/perspective.h
@@ -14,6 +14,8 @@ namespace camera {
 
 class perspective final : public base {
 public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     perspective(const std::string& name, const setup_type_t& setup_type, const color_order_t& color_order,
                 const unsigned int cols, const unsigned int rows, const double fps,
                 const double fx, const double fy, const double cx, const double cy,


### PR DESCRIPTION
This PR addresses the following warning:
```
/openvslam/src/openvslam/config.cc: In constructor 'openvslam::config::config(const string&)':
/openvslam/src/openvslam/config.cc:34:57: warning: 'new' of type 'openvslam::camera::fisheye' with extended alignment 32 [-Waligned-new=]
                 camera_ = new camera::fisheye(yaml_node_);
                                                         ^
/openvslam/src/openvslam/config.cc:34:57: note: uses 'void* operator new(std::size_t)', which does not have an alignment parameter
/openvslam/src/openvslam/config.cc:34:57: note: use '-faligned-new' to enable C++17 over-aligned new support
```