### PR TITLE
Minor additions to help build OpenVSLAM using Visual Studio

### DIFF
--- a/src/openvslam/camera/fisheye.cc
+++ b/src/openvslam/camera/fisheye.cc
@@ -84,7 +84,7 @@ image_bounds fisheye::compute_image_bounds() const {
         const double pwy = (0.0 - cy_) / fy_;
         const double theta_d = sqrt(pwx * pwx + pwy * pwy);
 
-        if (theta_d > M_PI_2) {
+        if (theta_d > M_PI / 2) {
             // fov is super wide (four corners are out of view)
 
             // corner coordinates: (x, y) = (col, row)

--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -33,6 +33,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *******************************************************************************/
 
+// Visual Studio only: we need M_PI and M_PI_2
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#include <cmath>
+#endif // _MSC_VER
+
 #include "openvslam/feature/orb_extractor.h"
 #include "openvslam/feature/orb_point_pairs.h"
 #include "openvslam/util/trigonometric.h"

--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -33,15 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 *******************************************************************************/
 
-// Visual Studio only: we need M_PI and M_PI_2
-#ifdef _MSC_VER
-#define _USE_MATH_DEFINES
-#include <cmath>
-#endif // _MSC_VER
-
 #include "openvslam/feature/orb_extractor.h"
 #include "openvslam/feature/orb_point_pairs.h"
 #include "openvslam/util/trigonometric.h"
+#include "openvslam/type.h"
 
 #include <opencv2/core.hpp>
 #include <opencv2/imgproc.hpp>

--- a/src/openvslam/feature/orb_extractor_node.h
+++ b/src/openvslam/feature/orb_extractor_node.h
@@ -2,6 +2,7 @@
 #define OPENVSLAM_FEATURE_ORB_EXTRACTOR_NODE_H
 
 #include <list>
+#include <array>
 
 #include <opencv2/core/types.hpp>
 

--- a/src/openvslam/type.h
+++ b/src/openvslam/type.h
@@ -1,12 +1,6 @@
 #ifndef OPENVSLAM_TYPE_H
 #define OPENVSLAM_TYPE_H
 
-// Visual Studio only: we need M_PI and M_PI_2
-#ifdef _MSC_VER
-#define _USE_MATH_DEFINES
-#include <cmath>
-#endif // _MSC_VER
-
 #include <vector>
 #include <map>
 #include <set>
@@ -16,6 +10,12 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <opencv2/core/types.hpp>
+
+#ifndef M_PI
+// M_PI is not part of the C++ standard. Rather it is part of the POSIX standard. As such,
+// it is not directly available on Visual C++ (although _USE_MATH_DEFINES does exist).
+#define M_PI 3.14159265358979323846
+#endif
 
 namespace openvslam {
 

--- a/src/openvslam/type.h
+++ b/src/openvslam/type.h
@@ -1,6 +1,12 @@
 #ifndef OPENVSLAM_TYPE_H
 #define OPENVSLAM_TYPE_H
 
+// Visual Studio only: we need M_PI and M_PI_2
+#ifdef _MSC_VER
+#define _USE_MATH_DEFINES
+#include <cmath>
+#endif // _MSC_VER
+
 #include <vector>
 #include <map>
 #include <set>

--- a/src/pangolin_viewer/color_scheme.cc
+++ b/src/pangolin_viewer/color_scheme.cc
@@ -1,5 +1,7 @@
 #include "pangolin_viewer/color_scheme.h"
 
+#include <cctype>
+
 namespace pangolin_viewer {
 
 color_scheme::color_scheme(const std::string& color_set_str) {


### PR DESCRIPTION
It seems that in order to build OpenVSLAM using Visual Studio, people have to keep adding pretty much these same changes over and over again (see e.g. [here](https://qiita.com/na0ki_ikeda/items/2310dc8dd70713de98e1#openvslamcmakeliststxt%E3%82%92%E7%B7%A8%E9%9B%86) and [here](https://github.com/xdspacelab/openvslam/issues/108#issuecomment-543720154)).

As these minor additions should cause no harm to Linux or macOS users, would suggest incorporating them in the official codebase.