### PR TITLE
added dep for eigen

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -124,6 +124,8 @@ Install the dependencies via ``apt``.
     apt install -y libgtk-3-dev
     apt install -y ffmpeg
     apt install -y libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavresample-dev
+    # eigen dependencies
+    apt install -y gfortran
     # other dependencies
     apt install -y libyaml-cpp-dev libgoogle-glog-dev libgflags-dev 
 


### PR DESCRIPTION
tiny fix.  originally got this when building eigen:
```
-- Looking for Fortran sgemm
CMake Error: CMAKE_Fortran_COMPILER not set, after EnableLanguage
CMake Error at /usr/share/cmake-3.10/Modules/CheckFortranFunctionExists.cmake:45 (try_compile):
  Failed to configure test project build system.
Call Stack (most recent call first):
  cmake/FindBLAS.cmake:297 (check_fortran_function_exists)
  cmake/FindBLAS.cmake:1297 (check_fortran_libraries)
  cmake/FindLAPACK.cmake:138 (find_package)
  test/CMakeLists.txt:30 (find_package)
```
