### PR TITLE
Disable the build support for OpenEXR in TravisCI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ before_install:
     cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -DBUILD_PANGOLIN_LIBOPENEXR=OFF \
         ..
     make -j 3
     make install


### PR DESCRIPTION
Recently (since about two weeks ago), the following build error has been appeared in Travis CI log.

```
Undefined symbols for architecture x86_64:
  "Imf_2_3::OutputFile::writePixels(int)", referenced from:
      pangolin::SaveExr(pangolin::Image<unsigned char> const&, pangolin::PixelFormat const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) in image_io_exr.cpp.o
  "Imf_2_3::OutputFile::setFrameBuffer(Imf_2_3::FrameBuffer const&)", referenced from:
      pangolin::SaveExr(pangolin::Image<unsigned char> const&, pangolin::PixelFormat const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) in image_io_exr.cpp.o
  "Imf_2_3::OutputFile::OutputFile(char const*, Imf_2_3::Header const&, int)", referenced from:
      pangolin::SaveExr(pangolin::Image<unsigned char> const&, pangolin::PixelFormat const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) in image_io_exr.cpp.o
  "Imf_2_3::OutputFile::~OutputFile()", referenced from:
      pangolin::SaveExr(pangolin::Image<unsigned char> const&, pangolin::PixelFormat const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) in image_io_exr.cpp.o
  "Imf_2_3::ChannelList::end()", referenced from:
      pangolin::SaveExr(pangolin::Image<unsigned char> const&, pangolin::PixelFormat const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool) in image_io_exr.cpp.o
(snip)
```

It seems that this error message is caused by failure in linking Pangolin with OpenEXR library.
But we are not sure why the link of OpenEXR fails, so OpenEXR support of Pangolin is disabled for TravisCI as an ad hoc fix in this PR.