### PR TITLE
Use correct end iterator in case keyframe is added

### DIFF
--- a/src/openvslam/tracking_module.cc
+++ b/src/openvslam/tracking_module.cc
@@ -474,6 +474,7 @@ void tracking_module::update_local_keyframes() {
         const auto neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);
         for (auto neighbor : neighbors) {
             if (add_local_keyframe(neighbor)) {
+                end = local_keyfrms_.cend();
                 break;
             }
         }
@@ -482,13 +483,16 @@ void tracking_module::update_local_keyframes() {
         const auto spanning_children = keyfrm->graph_node_->get_spanning_children();
         for (auto child : spanning_children) {
             if (add_local_keyframe(child)) {
+                end = local_keyfrms_.cend();
                 break;
             }
         }
 
         // parent of the spanning tree
         auto parent = keyfrm->graph_node_->get_spanning_parent();
-        add_local_keyframe(parent);
+        if (add_local_keyframe(parent)) {
+            end = local_keyfrms_.cend();
+        }
     }
 
     // update the reference keyframe with the nearest one

--- a/src/openvslam/tracking_module.cc
+++ b/src/openvslam/tracking_module.cc
@@ -463,7 +463,7 @@ void tracking_module::update_local_keyframes() {
         local_keyfrms_.push_back(keyfrm);
         return true;
     };
-    for (auto iter = local_keyfrms_.cbegin(), end = local_keyfrms_.cend(); iter != end; ++iter) {
+    for (auto iter = local_keyfrms_.cbegin(); iter != local_keyfrms_.cend(); ++iter) {
         if (max_num_local_keyfrms < local_keyfrms_.size()) {
             break;
         }
@@ -474,7 +474,6 @@ void tracking_module::update_local_keyframes() {
         const auto neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);
         for (auto neighbor : neighbors) {
             if (add_local_keyframe(neighbor)) {
-                end = local_keyfrms_.cend();
                 break;
             }
         }
@@ -483,16 +482,13 @@ void tracking_module::update_local_keyframes() {
         const auto spanning_children = keyfrm->graph_node_->get_spanning_children();
         for (auto child : spanning_children) {
             if (add_local_keyframe(child)) {
-                end = local_keyfrms_.cend();
                 break;
             }
         }
 
         // parent of the spanning tree
         auto parent = keyfrm->graph_node_->get_spanning_parent();
-        if (add_local_keyframe(parent)) {
-            end = local_keyfrms_.cend();
-        }
+        add_local_keyframe(parent);
     }
 
     // update the reference keyframe with the nearest one


### PR DESCRIPTION
Resolves #221.

(Creating a separate PR, as per @shinsumicco's comment [here](https://github.com/xdspacelab/openvslam/pull/217#discussion_r385064255).)

The problem appears to be that after adding a local keyframe, the previously acquired `end` iterator isn't valid anymore ([if the vector needs to re-allocate](https://bytes.com/topic/c/answers/584854-does-push_back-invalidate-existing-vector-iterators)).

Note that when it's done like this, it means that the newly added keyframes _will_ be processed during this loop. Not sure if that is the intention? If not, then it'd probably be more clear to use an index and not an iterator to iterate over the vector.