### PR TITLE
Fixed undefined behavior

### DIFF
--- a/src/openvslam/feature/orb_extractor.cc
+++ b/src/openvslam/feature/orb_extractor.cc
@@ -616,7 +616,7 @@ float orb_extractor::ic_angle(const cv::Mat& image, const cv::Point2f& point) co
 
     const auto step = static_cast<int>(image.step1());
     for (int v = 1; v <= fast_half_patch_size_; ++v) {
-        unsigned int v_sum = 0;
+        int v_sum = 0;
         const int d = u_max_.at(v);
         for (int u = -d; u <= d; ++u) {
             const int val_plus = center[u + v * step];


### PR DESCRIPTION
Tiny fix.

At `openvslam::feature::orb_extractor::ic_angle`, after [this line](https://github.com/xdspacelab/openvslam/blob/bab10083d100cc43e39f67e298bd21cc5ef1b66f/src/openvslam/feature/orb_extractor.cc#L624), `v_sum` which is unsigned can be negative.  
(e.g. center[u + v * step] == 2 && center[u - v * step] == 3)

If it happens, v_sum is going to be greater than `std::numeric_limits<int>::max();`. After that, at [this line](https://github.com/xdspacelab/openvslam/blob/bab10083d100cc43e39f67e298bd21cc5ef1b66f/src/openvslam/feature/orb_extractor.cc#L627), `m_01` will have overflowed.  This is undefined behavior and it is potential risks in the future.  
(e.g. https://wandbox.org/permlink/ISdtsJKewxNP63Dp , results are unpredictable)

Regerdless that, `v_sum` shall be, I think, `signed int` considering the intention of the author.