### PR TITLE
Fixed boundary check

### DIFF
--- a/src/openvslam/match/stereo.cc
+++ b/src/openvslam/match/stereo.cc
@@ -189,8 +189,8 @@ bool stereo::compute_subpixel_disparity(const cv::KeyPoint& keypt_left, const cv
     // パッチの移動範囲を計算し，範囲外であれば破棄
     constexpr int win_size = 5;
     constexpr int slide_width = 5;
-    const int ini_x = scaled_x_right + slide_width - win_size;
-    const int end_x = scaled_x_right + slide_width + win_size + 1;
+    const int ini_x = scaled_x_right - slide_width - win_size;
+    const int end_x = scaled_x_right + slide_width + win_size;
     if (ini_x < 0 || right_image_pyramid_.at(keypt_left.octave).cols <= end_x) {
         return false;
     }


### PR DESCRIPTION
SSIA.

As you know...
at `stereo::compute_subpixel_disparity`,   
x is (`base_x` + `slide_offset` + `window_offset`)   
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; where {
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `base_x` = _scaled_x_right_
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `slide_offset` ∈ [ - _slide_width_, + _slide_width_ ]
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; `window_offset` ∈ [ - _win_size_, _win_size_ ]
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; }

So, x ∈ [ _scaled_x_right_ - _slide_width_ - _win_size_, _scaled_x_right_ + _slide_width_ + _win_size_ + 1 ).  
Thus x ∈ [ _scaled_x_right_ - _slide_width_ - _win_size_, _scaled_x_right_ + _slide_width_ + _win_size_ ].

That's why   
```cpp
const int ini_x = scaled_x_right - slide_width - win_size;
const int end_x = scaled_x_right + slide_width + win_size;
```
is correct.

(since `assert(!(right_image_pyramid_.at(keypt_left.octave).cols <= end_x))` means `assert(end_x < right_image_pyramid_.at(keypt_left.octave).cols)`, [ini_x, end_x] must be closed interval.)