### PR TITLE
Move tracking parameters to tracking_module

### DIFF
--- a/src/openvslam/config.cc
+++ b/src/openvslam/config.cc
@@ -54,59 +54,6 @@ config::config(const YAML::Node& yaml_node, const std::string& config_file_path)
         camera_ = nullptr;
         throw;
     }
-
-    //=====================//
-    // Load ORB Parameters //
-    //=====================//
-
-    spdlog::debug("load ORB parameters");
-    try {
-        orb_params_ = feature::orb_params(yaml_node_);
-    }
-    catch (const std::exception& e) {
-        spdlog::debug("failed in loading ORB parameters: {}", e.what());
-        delete camera_;
-        camera_ = nullptr;
-        throw;
-    }
-
-    //==========================//
-    // Load Tracking Parameters //
-    //==========================//
-
-    spdlog::debug("load tracking parameters");
-
-    spdlog::debug("load depth threshold");
-    if (camera_->setup_type_ == camera::setup_type_t::Stereo || camera_->setup_type_ == camera::setup_type_t::RGBD) {
-        // ベースライン長の一定倍より遠いdepthは無視する
-        const auto depth_thr_factor = yaml_node_["depth_threshold"].as<double>(40.0);
-
-        switch (camera_->model_type_) {
-            case camera::model_type_t::Perspective: {
-                auto camera = static_cast<camera::perspective*>(camera_);
-                true_depth_thr_ = camera->true_baseline_ * depth_thr_factor;
-                break;
-            }
-            case camera::model_type_t::Fisheye: {
-                auto camera = static_cast<camera::fisheye*>(camera_);
-                true_depth_thr_ = camera->true_baseline_ * depth_thr_factor;
-                break;
-            }
-            case camera::model_type_t::Equirectangular: {
-                throw std::runtime_error("Not implemented: Stereo or RGBD of equirectangular camera model");
-            }
-            case camera::model_type_t::RadialDivision: {
-                auto camera = static_cast<camera::radial_division*>(camera_);
-                true_depth_thr_ = camera->true_baseline_ * depth_thr_factor;
-                break;
-            }
-        }
-    }
-
-    spdlog::debug("load depthmap factor");
-    if (camera_->setup_type_ == camera::setup_type_t::RGBD) {
-        depthmap_factor_ = yaml_node_["depthmap_factor"].as<double>(1.0);
-    }
 }
 
 config::~config() {
@@ -119,20 +66,6 @@ config::~config() {
 std::ostream& operator<<(std::ostream& os, const config& cfg) {
     std::cout << "Camera Configuration:" << std::endl;
     cfg.camera_->show_parameters();
-
-    std::cout << "ORB Configuration:" << std::endl;
-    cfg.orb_params_.show_parameters();
-
-    if (cfg.camera_->setup_type_ == camera::setup_type_t::Stereo || cfg.camera_->setup_type_ == camera::setup_type_t::RGBD) {
-        std::cout << "Stereo Configuration:" << std::endl;
-        std::cout << "- true baseline: " << cfg.camera_->true_baseline_ << std::endl;
-        std::cout << "- true depth threshold: " << cfg.true_depth_thr_ << std::endl;
-        std::cout << "- depth threshold factor: " << cfg.true_depth_thr_ / cfg.camera_->true_baseline_ << std::endl;
-    }
-    if (cfg.camera_->setup_type_ == camera::setup_type_t::RGBD) {
-        std::cout << "Depth Image Configuration:" << std::endl;
-        std::cout << "- depthmap factor: " << cfg.depthmap_factor_ << std::endl;
-    }
 
     return os;
 }

--- a/src/openvslam/config.h
+++ b/src/openvslam/config.h
@@ -27,15 +27,6 @@ public:
 
     //! Camera model
     camera::base* camera_ = nullptr;
-
-    //! ORB feature parameters
-    feature::orb_params orb_params_;
-
-    //! depth threshold
-    double true_depth_thr_ = 40.0;
-
-    //! depthmap factor (pixel_value / depthmap_factor = true_depth)
-    double depthmap_factor_ = 1.0;
 };
 
 } // namespace openvslam

--- a/src/openvslam/tracking_module.h
+++ b/src/openvslam/tracking_module.h
@@ -102,13 +102,19 @@ public:
     void resume();
 
     //-----------------------------------------
-    // variables
+    // configurations
 
-    //! config
-    const std::shared_ptr<config> cfg_;
-
-    //! camera model (equals to cfg_->camera_)
+    //! camera model
     camera::base* camera_;
+
+    //! depth threshold (Ignore depths farther than true_depth_thr_ times the baseline.)
+    double true_depth_thr_ = 40.0;
+
+    //! depthmap factor (pixel_value / depthmap_factor = true_depth)
+    double depthmap_factor_ = 1.0;
+
+    //-----------------------------------------
+    // variables
 
     //! latest tracking state
     tracker_state_t tracking_state_ = tracker_state_t::NotInitialized;


### PR DESCRIPTION
This PR changes the parameters of tracking_module to be loaded in the `tracking_module` instead of the `config`.
It follows the 4th principle of [Best Practices for Working with Configuration in Python Applications](https://tech.preferred.jp/en/blog/working-with-configuration-in-python/.)
(This is the preparation for adding configurable parameters to the mapping_module.)