### PR TITLE
Uninstall signal handler in ros2

### DIFF
--- a/ros/2/src/openvslam/src/run_localization.cc
+++ b/ros/2/src/openvslam/src/run_localization.cc
@@ -134,6 +134,7 @@ int main(int argc, char* argv[]) {
     google::InstallFailureSignalHandler();
 #endif
     rclcpp::init(argc, argv);
+    rclcpp::uninstall_signal_handlers();
 
     // create options
     popl::OptionParser op("Allowed options");

--- a/ros/2/src/openvslam/src/run_slam.cc
+++ b/ros/2/src/openvslam/src/run_slam.cc
@@ -145,6 +145,7 @@ int main(int argc, char* argv[]) {
     google::InstallFailureSignalHandler();
 #endif
     rclcpp::init(argc, argv);
+    rclcpp::uninstall_signal_handlers();
 
     // create options
     popl::OptionParser op("Allowed options");


### PR DESCRIPTION
`Ctrl+C` didn't work in ros2, so I fixed it.