### PR TITLE
Add documentation for ROS2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Contents
     ./simple_tutorial
     ./example
     ./docker
-    ./ros_package
+    ./ros
     ./trouble_shooting
 
 Cite Us

--- a/docs/ros.rst
+++ b/docs/ros.rst
@@ -1,0 +1,18 @@
+.. _chapter-ros:
+
+==============
+Running on ROS
+==============
+
+We provide ROS and ROS2 package examples to help you run OpenVSLAM on ROS framework.
+
+.. NOTE ::
+
+    Please build OpenVSLAM with **OpenCV 3.3.1 or later** if you plan on using ROS package.
+    OpenCV 4.x is not supported yet.
+
+.. toctree::
+    :maxdepth: 2
+
+    ./ros_package
+    ./ros2_package

--- a/docs/ros2_package.rst
+++ b/docs/ros2_package.rst
@@ -1,0 +1,204 @@
+.. _chapter-ros-package:
+
+===========
+ROS Package
+===========
+
+We provide ROS package examples to help you run OpenVSLAM on ROS framework.
+
+.. NOTE ::
+
+    Please build OpenVSLAM with **OpenCV 3.3.1 or later** if you plan on using ROS package.
+    OpenCV 4.x is not supported yet.
+
+.. _section-installation:
+
+Installation
+============
+
+Requirements
+^^^^^^^^^^^^
+
+* `ROS <http://wiki.ros.org/>`_ : Please use the version ``kinetic`` or later.
+
+* :ref:`OpenVSLAM <chapter-installation>` : Please build it with **OpenCV 3.x**.
+
+* `image_transport <http://wiki.ros.org/image_transport>`_ : Required by this ROS package examples.
+
+* `cv_bridge <http://wiki.ros.org/cv_bridge>`_ : Please build it with the same version of OpenCV used in OpenVSLAM. (**We recommend building it from source.**)
+
+.. _section-prerequisites:
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Tested for **Ubuntu 16.04**.
+
+Please install the following dependencies.
+
+* ROS : Please follow `Installation of ROS <http://wiki.ros.org/ROS/Installation>`_.
+
+* OpenVSLAM : Please follow :ref:`Installation of OpenVSLAM <chapter-installation>`.
+
+.. NOTE ::
+
+    Please build OpenVSLAM with PangolinViewer or SocketViewer if you plan on using it for the examples.
+
+Install the dependencies via ``apt``.
+
+.. code-block:: bash
+
+    apt update -y
+    apt install ros-${ROS_DISTRO}-image-transport
+
+Download the source of ``cv_bridge``.
+
+.. code-block:: bash
+
+    cd /path/to/openvslam/ros
+    git clone --branch ${ROS_DISTRO} --depth 1 https://github.com/ros-perception/vision_opencv.git
+    cp -r vision_opencv/cv_bridge src/
+    rm -rf vision_opencv
+
+.. NOTE ::
+
+    We recommend building ``cv_bridge`` from the source even if it has been installed via ``apt``.
+
+Build Instructions
+^^^^^^^^^^^^^^^^^^
+
+When building with support for PangolinViewer, please specify the following cmake options: ``-DUSE_PANGOLIN_VIEWER=ON`` and ``-DUSE_SOCKET_PUBLISHER=OFF`` as described in :ref:`build of OpenVSLAM <section-build-unix>`.
+
+.. code-block:: bash
+
+    cd /path/to/openvslam/ros
+    catkin_make \
+        -DBUILD_WITH_MARCH_NATIVE=ON \
+        -DUSE_PANGOLIN_VIEWER=ON \
+        -DUSE_SOCKET_PUBLISHER=OFF \
+        -DUSE_STACK_TRACE_LOGGER=ON \
+        -DBOW_FRAMEWORK=DBoW2
+
+Alternatively, when building with support for SocketViewer, please specify the following cmake options: ``-DUSE_PANGOLIN_VIEWER=OFF`` and ``-DUSE_SOCKET_PUBLISHER=ON`` as described in :ref:`build of OpenVSLAM <section-build-unix>`.
+
+.. code-block:: bash
+
+    cd /path/to/openvslam/ros
+    catkin_make \
+        -DBUILD_WITH_MARCH_NATIVE=ON \
+        -DUSE_PANGOLIN_VIEWER=OFF \
+        -DUSE_SOCKET_PUBLISHER=ON \
+        -DUSE_STACK_TRACE_LOGGER=ON \
+        -DBOW_FRAMEWORK=DBoW2
+
+Examples
+========
+
+Run the core program required for ROS-based system in advance.
+
+.. code-block:: bash
+
+    roscore
+
+.. NOTE ::
+
+    Please leave the **roscore** run.
+
+Publisher
+^^^^^^^^^
+
+Publishers continually broadcast images as a ROS topic.
+Please execute one of the following command snippets in the new terminal.
+
+Publish a Video File
+--------------------
+
+For using video files (e.g. ``.mp4``) for visual SLAM or localization.
+
+.. code-block:: bash
+
+    source /path/to/openvslam/ros/devel/setup.bash
+    rosrun publisher video -m /path/to/video.mp4
+
+Republish the ROS topic to ``/camera/image_raw``.
+
+.. code-block:: bash
+
+    rosrun image_transport republish \
+        raw in:=/video/image_raw raw out:=/camera/image_raw
+
+
+Publish a Image Sequence
+------------------------
+
+For using image sequences for visual SLAM or localization.
+
+.. code-block:: bash
+
+    source /path/to/openvslam/ros/devel/setup.bash
+    rosrun publisher image -i /path/to/images/
+
+Republish the ROS topic to ``/camera/image_raw``.
+
+.. code-block:: bash
+
+    rosrun image_transport republish \
+        raw in:=/video/image_raw raw out:=/camera/image_raw
+
+Publish Images of a USB Camera
+------------------------------
+
+For using a standard USB camera for visual SLAM or localization.
+
+.. code-block:: bash
+
+    apt install ros-${ROS_DISTRO}-usb-cam
+
+.. code-block:: bash
+
+    rosparam set usb_cam/pixel_format yuyv
+    rosrun usb_cam usb_cam_node
+
+Republish the ROS topic to ``/camera/image_raw``.
+
+.. code-block:: bash
+
+    rosrun image_transport republish \
+        raw in:=/usb_cam/image_raw raw out:=/camera/image_raw
+
+Subscriber
+^^^^^^^^^^
+
+Subscribers continually receive images.
+Please execute one of the following command snippets in the new terminal.
+
+.. NOTE ::
+
+    Option arguments are the same as :ref:`the examples of OpenVSLAM <chapter-example>`.
+
+Tracking and Mapping
+--------------------
+
+We provide an example snippet for visual SLAM.
+The source code is placed at ``./openvslam/ros/src/openvslam/src/run_slam.cc``.
+
+.. code-block:: bash
+
+    source /path/to/openvslam/ros/devel/setup.bash
+    rosrun openvslam run_slam \
+        -v /path/to/orb_vocab.dbow2 \
+        -c /path/to/config.yaml
+
+Localization
+------------
+
+We provide an example snippet for localization based on a prebuilt map.
+The source code is placed at ``./ros/src/openvslam/src/run_localization.cc``.
+
+.. code-block:: bash
+
+    source /path/to/openvslam/ros/devel/setup.bash
+    rosrun openvslam run_localization \
+        -v /path/to/orb_vocab.dbow2 \
+        -c /path/to/config.yaml \
+        --map-db /path/to/map.msg

--- a/docs/ros2_package.rst
+++ b/docs/ros2_package.rst
@@ -1,10 +1,10 @@
 .. _chapter-ros-package:
 
-===========
-ROS Package
-===========
+============
+ROS2 Package
+============
 
-We provide ROS package examples to help you run OpenVSLAM on ROS framework.
+We provide ROS2 package examples to help you run OpenVSLAM on ROS2 framework.
 
 .. NOTE ::
 
@@ -19,24 +19,26 @@ Installation
 Requirements
 ^^^^^^^^^^^^
 
-* `ROS <http://wiki.ros.org/>`_ : Please use the version ``kinetic`` or later.
+* `ROS2 <https://index.ros.org/doc/ros2//>`_ : Please use the version ``dashing`` or later.
 
 * :ref:`OpenVSLAM <chapter-installation>` : Please build it with **OpenCV 3.x**.
 
-* `image_transport <http://wiki.ros.org/image_transport>`_ : Required by this ROS package examples.
+* `image_common <https://index.ros.org/r/image_common/github-ros-perception-image_common>`_ : Required by this ROS package examples.
 
-* `cv_bridge <http://wiki.ros.org/cv_bridge>`_ : Please build it with the same version of OpenCV used in OpenVSLAM. (**We recommend building it from source.**)
+* `vision_opencv <https://index.ros.org/r/vision_opencv/github-ros-perception-vision_opencv>`_ : Please build it with the same version of OpenCV used in OpenVSLAM. (**We recommend building it from source.**)
+
+* `image_tools <https://index.ros.org/p/image_tools/#dashing>`_ : An optional requirement to use USB cameras.
 
 .. _section-prerequisites:
 
 Prerequisites
 ^^^^^^^^^^^^^
 
-Tested for **Ubuntu 16.04**.
+Tested for **Ubuntu 18.04**.
 
 Please install the following dependencies.
 
-* ROS : Please follow `Installation of ROS <http://wiki.ros.org/ROS/Installation>`_.
+* ROS2 : Please follow `Installation of ROS2 <https://index.ros.org/doc/ros2/Installation/>`_.
 
 * OpenVSLAM : Please follow :ref:`Installation of OpenVSLAM <chapter-installation>`.
 
@@ -44,65 +46,37 @@ Please install the following dependencies.
 
     Please build OpenVSLAM with PangolinViewer or SocketViewer if you plan on using it for the examples.
 
-Install the dependencies via ``apt``.
+Download repositories of ``image_common`` and ``vision_opencv``.
 
 .. code-block:: bash
 
-    apt update -y
-    apt install ros-${ROS_DISTRO}-image-transport
+    cd /path/to/openvslam/ros/2/src
+    git clone -b dashing --single-branch https://github.com/ros-perception/image_common.git
+    git clone -b ros2 --single-branch https://github.com/ros-perception/vision_opencv.git
 
-Download the source of ``cv_bridge``.
+For using USB cam as a image source, donload a repository of ``demos`` and pick ``image_tools`` module.
 
 .. code-block:: bash
 
-    cd /path/to/openvslam/ros
-    git clone --branch ${ROS_DISTRO} --depth 1 https://github.com/ros-perception/vision_opencv.git
-    cp -r vision_opencv/cv_bridge src/
-    rm -rf vision_opencv
-
-.. NOTE ::
-
-    We recommend building ``cv_bridge`` from the source even if it has been installed via ``apt``.
+    cd /path/to/openvslam/ros/2
+    git clone https://github.com/ros2/demos.git
+    cp -r demos/image_tools src/
+    rm -rf demos
 
 Build Instructions
 ^^^^^^^^^^^^^^^^^^
 
-When building with support for PangolinViewer, please specify the following cmake options: ``-DUSE_PANGOLIN_VIEWER=ON`` and ``-DUSE_SOCKET_PUBLISHER=OFF`` as described in :ref:`build of OpenVSLAM <section-build-unix>`.
+When building with support for PangolinViewer, you have not specify any arguments.
 
 .. code-block:: bash
 
-    cd /path/to/openvslam/ros
-    catkin_make \
-        -DBUILD_WITH_MARCH_NATIVE=ON \
-        -DUSE_PANGOLIN_VIEWER=ON \
-        -DUSE_SOCKET_PUBLISHER=OFF \
-        -DUSE_STACK_TRACE_LOGGER=ON \
-        -DBOW_FRAMEWORK=DBoW2
+    cd /path/to/openvslam/ros/2
+    colcon buld --symlink-install
 
-Alternatively, when building with support for SocketViewer, please specify the following cmake options: ``-DUSE_PANGOLIN_VIEWER=OFF`` and ``-DUSE_SOCKET_PUBLISHER=ON`` as described in :ref:`build of OpenVSLAM <section-build-unix>`.
-
-.. code-block:: bash
-
-    cd /path/to/openvslam/ros
-    catkin_make \
-        -DBUILD_WITH_MARCH_NATIVE=ON \
-        -DUSE_PANGOLIN_VIEWER=OFF \
-        -DUSE_SOCKET_PUBLISHER=ON \
-        -DUSE_STACK_TRACE_LOGGER=ON \
-        -DBOW_FRAMEWORK=DBoW2
+The SocketViewer is not available right now. We will provide this feature soon.
 
 Examples
 ========
-
-Run the core program required for ROS-based system in advance.
-
-.. code-block:: bash
-
-    roscore
-
-.. NOTE ::
-
-    Please leave the **roscore** run.
 
 Publisher
 ^^^^^^^^^
@@ -117,14 +91,14 @@ For using video files (e.g. ``.mp4``) for visual SLAM or localization.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
-    rosrun publisher video -m /path/to/video.mp4
+    source /path/to/openvslam/ros/2/install/setup.bash
+    ros2 run publisher video -m /path/to/video.mp4
 
 Republish the ROS topic to ``/camera/image_raw``.
 
 .. code-block:: bash
 
-    rosrun image_transport republish \
+    ros2 run image_transport republish \
         raw in:=/video/image_raw raw out:=/camera/image_raw
 
 
@@ -135,14 +109,14 @@ For using image sequences for visual SLAM or localization.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
-    rosrun publisher image -i /path/to/images/
+    source /path/to/openvslam/ros/2/install/setup.bash
+    ros2 run publisher image -i /path/to/images/
 
 Republish the ROS topic to ``/camera/image_raw``.
 
 .. code-block:: bash
 
-    rosrun image_transport republish \
+    ros2 run image_transport republish \
         raw in:=/video/image_raw raw out:=/camera/image_raw
 
 Publish Images of a USB Camera
@@ -152,19 +126,14 @@ For using a standard USB camera for visual SLAM or localization.
 
 .. code-block:: bash
 
-    apt install ros-${ROS_DISTRO}-usb-cam
-
-.. code-block:: bash
-
-    rosparam set usb_cam/pixel_format yuyv
-    rosrun usb_cam usb_cam_node
+    ros2 run image_tools cam2image
 
 Republish the ROS topic to ``/camera/image_raw``.
 
 .. code-block:: bash
 
     rosrun image_transport republish \
-        raw in:=/usb_cam/image_raw raw out:=/camera/image_raw
+        raw in:=image raw out:=/camera/image_raw
 
 Subscriber
 ^^^^^^^^^^
@@ -184,8 +153,8 @@ The source code is placed at ``./openvslam/ros/src/openvslam/src/run_slam.cc``.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
-    rosrun openvslam run_slam \
+    source /path/to/openvslam/ros/2/install/setup.bash
+    ros2 run openvslam run_slam \
         -v /path/to/orb_vocab.dbow2 \
         -c /path/to/config.yaml
 
@@ -197,8 +166,8 @@ The source code is placed at ``./ros/src/openvslam/src/run_localization.cc``.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
-    rosrun openvslam run_localization \
+    source /path/to/openvslam/ros/2/install/setup.bash
+    ros2 run openvslam run_localization \
         -v /path/to/orb_vocab.dbow2 \
         -c /path/to/config.yaml \
         --map-db /path/to/map.msg

--- a/docs/ros2_package.rst
+++ b/docs/ros2_package.rst
@@ -4,13 +4,6 @@
 ROS2 Package
 ============
 
-We provide ROS2 package examples to help you run OpenVSLAM on ROS2 framework.
-
-.. NOTE ::
-
-    Please build OpenVSLAM with **OpenCV 3.3.1 or later** if you plan on using ROS package.
-    OpenCV 4.x is not supported yet.
-
 .. _section-installation:
 
 Installation
@@ -119,7 +112,7 @@ Republish the ROS topic to ``/camera/image_raw``.
     ros2 run image_transport republish \
         raw in:=/video/image_raw raw out:=/camera/image_raw
 
-Publish Images of a USB Camera
+Publish Images Captured by a USB Camera
 ------------------------------
 
 For using a standard USB camera for visual SLAM or localization.

--- a/docs/ros_package.rst
+++ b/docs/ros_package.rst
@@ -55,7 +55,7 @@ Download the source of ``cv_bridge``.
 
 .. code-block:: bash
 
-    cd /path/to/openvslam/ros
+    cd /path/to/openvslam/ros/1
     git clone --branch ${ROS_DISTRO} --depth 1 https://github.com/ros-perception/vision_opencv.git
     cp -r vision_opencv/cv_bridge src/
     rm -rf vision_opencv
@@ -71,7 +71,7 @@ When building with support for PangolinViewer, please specify the following cmak
 
 .. code-block:: bash
 
-    cd /path/to/openvslam/ros
+    cd /path/to/openvslam/ros/1
     catkin_make \
         -DBUILD_WITH_MARCH_NATIVE=ON \
         -DUSE_PANGOLIN_VIEWER=ON \
@@ -83,7 +83,7 @@ Alternatively, when building with support for SocketViewer, please specify the f
 
 .. code-block:: bash
 
-    cd /path/to/openvslam/ros
+    cd /path/to/openvslam/ros/1
     catkin_make \
         -DBUILD_WITH_MARCH_NATIVE=ON \
         -DUSE_PANGOLIN_VIEWER=OFF \
@@ -117,7 +117,7 @@ For using video files (e.g. ``.mp4``) for visual SLAM or localization.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
+    source /path/to/openvslam/ros/1/devel/setup.bash
     rosrun publisher video -m /path/to/video.mp4
 
 Republish the ROS topic to ``/camera/image_raw``.
@@ -135,7 +135,7 @@ For using image sequences for visual SLAM or localization.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
+    source /path/to/openvslam/ros/1/devel/setup.bash
     rosrun publisher image -i /path/to/images/
 
 Republish the ROS topic to ``/camera/image_raw``.
@@ -180,11 +180,11 @@ Tracking and Mapping
 --------------------
 
 We provide an example snippet for visual SLAM.
-The source code is placed at ``./openvslam/ros/src/openvslam/src/run_slam.cc``.
+The source code is placed at ``./openvslam/ros/1/src/openvslam/src/run_slam.cc``.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
+    source /path/to/openvslam/ros/1/devel/setup.bash
     rosrun openvslam run_slam \
         -v /path/to/orb_vocab.dbow2 \
         -c /path/to/config.yaml
@@ -193,11 +193,11 @@ Localization
 ------------
 
 We provide an example snippet for localization based on a prebuilt map.
-The source code is placed at ``./ros/src/openvslam/src/run_localization.cc``.
+The source code is placed at ``./ros/1/src/openvslam/src/run_localization.cc``.
 
 .. code-block:: bash
 
-    source /path/to/openvslam/ros/devel/setup.bash
+    source /path/to/openvslam/ros/1/devel/setup.bash
     rosrun openvslam run_localization \
         -v /path/to/orb_vocab.dbow2 \
         -c /path/to/config.yaml \

--- a/docs/ros_package.rst
+++ b/docs/ros_package.rst
@@ -4,13 +4,6 @@
 ROS Package
 ===========
 
-We provide ROS package examples to help you run OpenVSLAM on ROS framework.
-
-.. NOTE ::
-
-    Please build OpenVSLAM with **OpenCV 3.3.1 or later** if you plan on using ROS package.
-    OpenCV 4.x is not supported yet.
-
 .. _section-installation:
 
 Installation


### PR DESCRIPTION
Updated documentation.
* Test and write the procedure for using OpenVSLAM by ROS2.
* Apply moving ROS(1) directory to documentation.
* Nest ROS and ROS2 packages into a single section named "Running on ROS".

Can I ask you where should I merge into?