### PR TITLE
keyframe index replaces iterator

### DIFF
--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -134,6 +134,7 @@ target_link_libraries(${PROJECT_NAME}
                       opencv_core
                       opencv_features2d
                       opencv_calib3d
+                      glog
                       g2o::core
                       g2o::stuff
                       g2o::types_sba

--- a/src/openvslam/CMakeLists.txt
+++ b/src/openvslam/CMakeLists.txt
@@ -134,7 +134,6 @@ target_link_libraries(${PROJECT_NAME}
                       opencv_core
                       opencv_features2d
                       opencv_calib3d
-                      glog
                       g2o::core
                       g2o::stuff
                       g2o::types_sba

--- a/src/openvslam/tracking_module.cc
+++ b/src/openvslam/tracking_module.cc
@@ -466,12 +466,12 @@ void tracking_module::update_local_keyframes() {
         return true;
     };
 
-    for (unsigned kefrm_index = 0; kefrm_index < max_num_local_keyfrms; kefrm_index++) {
-        if (kefrm_index >= local_keyfrms_.size()) {
+    for (unsigned keyfrm_index = 0; keyfrm_index < max_num_local_keyfrms; keyfrm_index++) {
+        if (keyfrm_index >= local_keyfrms_.size()) {
             break;
         }
 
-        auto keyfrm = local_keyfrms_.at(kefrm_index);
+        auto keyfrm = local_keyfrms_.at(keyfrm_index);
 
         // covisibilities of the neighbor keyframe
         const auto neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);

--- a/src/openvslam/tracking_module.cc
+++ b/src/openvslam/tracking_module.cc
@@ -465,31 +465,17 @@ void tracking_module::update_local_keyframes() {
         local_keyfrms_.push_back(keyfrm);
         return true;
     };
-    // unsigned dbg_index = 0;
-    // this is problemtic: the for loop iterates on local_keyfrms_, but it also modifies
-    // local_keyfrms_. This mostly works, but when the list gets to be about 50, it fails
-    // with a segfault. Why? One suggestion is that it reallocates when you do that, and then
-    // you end up re-sizing the vector, and then you end up referencing an iterator that has
-    // been moved. One forum suggests using a list or a dequeue.
-    for (auto iter = local_keyfrms_.cbegin(); iter != local_keyfrms_.cend(); ++iter) {
-        if (max_num_local_keyfrms < local_keyfrms_.size()) {
+
+    for (unsigned kefrm_index = 0; kefrm_index < max_num_local_keyfrms; kefrm_index++) {
+        if (kefrm_index >= local_keyfrms_.size()) {
             break;
         }
-        // if (dbg_index >= local_keyfrms_.size()) {
-        //     LOG(INFO) << "Error: keyframe index " << dbg_index << " exceeds local_keyfrms_.size()" << local_keyfrms_.size();
-        //     LOG(WARNING) << "Error: keyframe index " << dbg_index << " exceeds local_keyfrms_.size()" << local_keyfrms_.size();
-        //     break;
-        // }
-        auto keyfrm = *iter;
+
+        auto keyfrm = local_keyfrms_.at(kefrm_index);
 
         // covisibilities of the neighbor keyframe
-        std::vector<openvslam::data::keyframe*> neighbors;
-        try {
-            neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);
-        }
-        catch (const std::exception& err) {
-            LOG(WARNING) << "Error in update_local_keyframes: " << err.what();
-        }
+        const auto neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);
+
         for (auto neighbor : neighbors) {
             if (add_local_keyframe(neighbor)) {
                 break;

--- a/src/openvslam/tracking_module.cc
+++ b/src/openvslam/tracking_module.cc
@@ -16,8 +16,6 @@
 
 #include <spdlog/spdlog.h>
 
-#include "glog/logging.h"
-
 namespace openvslam {
 
 tracking_module::tracking_module(const std::shared_ptr<config>& cfg, system* system, data::map_database* map_db,
@@ -465,7 +463,6 @@ void tracking_module::update_local_keyframes() {
         local_keyfrms_.push_back(keyfrm);
         return true;
     };
-
     for (unsigned keyfrm_index = 0; keyfrm_index < max_num_local_keyfrms; keyfrm_index++) {
         if (keyfrm_index >= local_keyfrms_.size()) {
             break;
@@ -475,7 +472,6 @@ void tracking_module::update_local_keyframes() {
 
         // covisibilities of the neighbor keyframe
         const auto neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);
-
         for (auto neighbor : neighbors) {
             if (add_local_keyframe(neighbor)) {
                 break;

--- a/src/openvslam/tracking_module.cc
+++ b/src/openvslam/tracking_module.cc
@@ -465,26 +465,31 @@ void tracking_module::update_local_keyframes() {
         local_keyfrms_.push_back(keyfrm);
         return true;
     };
-    unsigned dbg_index = 0;
+    // unsigned dbg_index = 0;
     // this is problemtic: the for loop iterates on local_keyfrms_, but it also modifies
     // local_keyfrms_. This mostly works, but when the list gets to be about 50, it fails
     // with a segfault. Why? One suggestion is that it reallocates when you do that, and then
     // you end up re-sizing the vector, and then you end up referencing an iterator that has
     // been moved. One forum suggests using a list or a dequeue.
-    for (auto iter = local_keyfrms_.cbegin(); iter != local_keyfrms_.cend(); iter++) {
+    for (auto iter = local_keyfrms_.cbegin(); iter != local_keyfrms_.cend(); ++iter) {
         if (max_num_local_keyfrms < local_keyfrms_.size()) {
             break;
         }
-        if (dbg_index >= local_keyfrms_.size()) {
-            LOG(INFO) << "Error: keyframe index " << dbg_index << " exceeds local_keyfrms_.size()" << local_keyfrms_.size();
-            LOG(WARNING) << "Error: keyframe index " << dbg_index << " exceeds local_keyfrms_.size()" << local_keyfrms_.size();
-            break;
-        }
+        // if (dbg_index >= local_keyfrms_.size()) {
+        //     LOG(INFO) << "Error: keyframe index " << dbg_index << " exceeds local_keyfrms_.size()" << local_keyfrms_.size();
+        //     LOG(WARNING) << "Error: keyframe index " << dbg_index << " exceeds local_keyfrms_.size()" << local_keyfrms_.size();
+        //     break;
+        // }
         auto keyfrm = *iter;
 
         // covisibilities of the neighbor keyframe
-        // TODO pbarsic this is where the segfault occurs
-        const auto neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);
+        std::vector<openvslam::data::keyframe*> neighbors;
+        try {
+            neighbors = keyfrm->graph_node_->get_top_n_covisibilities(10);
+        }
+        catch (const std::exception& err) {
+            LOG(WARNING) << "Error in update_local_keyframes: " << err.what();
+        }
         for (auto neighbor : neighbors) {
             if (add_local_keyframe(neighbor)) {
                 break;


### PR DESCRIPTION
This fixes an intermittent segfault that occurs when the iterator over the vector holding local keyframes does not point to a valid element.