### PR TITLE
Loading params for loop detection from yaml config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,11 +118,11 @@ before_install:
     cd ${DEPS_DIR}
     if [ ! -d socket.io-client-cpp ]; then
         echo "clone socket.io-client-cpp"
-        git clone https://github.com/shinsumicco/socket.io-client-cpp
+        git clone https://github.com/shinsumicco/socket.io-client-cpp.git
     elif [ -z "$(ls socket.io-client-cpp)" ]; then
         echo "reclone socket.io-client-cpp"
         rm -rf socket.io-client-cpp
-        git clone https://github.com/shinsumicco/socket.io-client-cpp
+        git clone https://github.com/shinsumicco/socket.io-client-cpp.git
     fi
     cd socket.io-client-cpp
     git submodule init

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -137,7 +137,7 @@ Install the dependencies via ``apt``.
     # Protobuf dependencies
     apt install -y autogen autoconf libtool
     # Node.js
-    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+    curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -
     apt install -y nodejs
 
 Download and install Eigen from source.
@@ -288,7 +288,7 @@ Download, build and install g2o.
 .. code-block:: bash
 
     cd /path/to/working/dir
-    git clone https://github.com/shinsumicco/socket.io-client-cpp
+    git clone https://github.com/shinsumicco/socket.io-client-cpp.git
     cd socket.io-client-cpp
     git submodule init
     git submodule update

--- a/src/openvslam/global_optimization_module.cc
+++ b/src/openvslam/global_optimization_module.cc
@@ -11,8 +11,9 @@
 namespace openvslam {
 
 global_optimization_module::global_optimization_module(data::map_database* map_db, data::bow_database* bow_db,
-                                                       data::bow_vocabulary* bow_vocab, const bool fix_scale)
-    : loop_detector_(new module::loop_detector(bow_db, bow_vocab, fix_scale)),
+                                                       data::bow_vocabulary* bow_vocab, const YAML::Node& yaml_node,
+                                                       const bool fix_scale)
+    : loop_detector_(new module::loop_detector(bow_db, bow_vocab, yaml_node, fix_scale)),
       loop_bundle_adjuster_(new module::loop_bundle_adjuster(map_db)),
       graph_optimizer_(new optimize::graph_optimizer(map_db, fix_scale)) {
     spdlog::debug("CONSTRUCT: global_optimization_module");

--- a/src/openvslam/global_optimization_module.h
+++ b/src/openvslam/global_optimization_module.h
@@ -27,7 +27,7 @@ class map_database;
 class global_optimization_module {
 public:
     //! Constructor
-    global_optimization_module(data::map_database* map_db, data::bow_database* bow_db, data::bow_vocabulary* bow_vocab, const bool fix_scale);
+    global_optimization_module(data::map_database* map_db, data::bow_database* bow_db, data::bow_vocabulary* bow_vocab, const YAML::Node& yaml_node, const bool fix_scale);
 
     //! Destructor
     ~global_optimization_module();

--- a/src/openvslam/module/loop_detector.h
+++ b/src/openvslam/module/loop_detector.h
@@ -23,7 +23,7 @@ public:
     /**
      * Constructor
      */
-    loop_detector(data::bow_database* bow_db, data::bow_vocabulary* bow_vocab, const bool fix_scale_in_Sim3_estimation);
+    loop_detector(data::bow_database* bow_db, data::bow_vocabulary* bow_vocab, const YAML::Node& yaml_node, const bool fix_scale_in_Sim3_estimation);
 
     /**
      * Enable loop detection
@@ -114,6 +114,12 @@ private:
     //! for stereo/RGBD models, fix scale when estimating Sim3
     const bool fix_scale_in_Sim3_estimation_;
 
+    //! the threshold of the number of mutual matches after the Sim3 estimation
+    const unsigned int num_final_matches_thr_;
+
+    //! the threshold of the continuity of continuously detected keyframe set
+    const unsigned int min_continuity_;
+
     //-----------------------------------------
     // variables for loop detection and correction
 
@@ -139,9 +145,6 @@ private:
 
     //! the keyframe ID when the previouls loop correction was performed
     unsigned int prev_loop_correct_keyfrm_id_ = 0;
-
-    //! the threshold of the continuity of continuously detected keyframe set
-    static constexpr unsigned int min_continuity_ = 3;
 };
 
 } // namespace module

--- a/src/openvslam/system.cc
+++ b/src/openvslam/system.cc
@@ -78,7 +78,7 @@ system::system(const std::shared_ptr<config>& cfg, const std::string& vocab_file
     // mapping module
     mapper_ = new mapping_module(map_db_, camera_->setup_type_ == camera::setup_type_t::Monocular);
     // global optimization module
-    global_optimizer_ = new global_optimization_module(map_db_, bow_db_, bow_vocab_, camera_->setup_type_ != camera::setup_type_t::Monocular);
+    global_optimizer_ = new global_optimization_module(map_db_, bow_db_, bow_vocab_, cfg_->yaml_node_, camera_->setup_type_ != camera::setup_type_t::Monocular);
 
     // connect modules each other
     tracker_->set_mapping_module(mapper_);

--- a/src/socket_publisher/CMakeLists.txt
+++ b/src/socket_publisher/CMakeLists.txt
@@ -29,6 +29,9 @@ add_library(socket_publisher
             ${CMAKE_CURRENT_SOURCE_DIR}/socket_client.cc
             ${MAP_PB_SOURCE})
 
+set_source_files_properties(${MAP_PB_SOURCE} PROPERTIES
+                            COMPILE_FLAGS -Wno-unused-parameter)
+
 set_target_properties(socket_publisher PROPERTIES
                       OUTPUT_NAME socket_publisher
                       ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib

--- a/src/socket_publisher/data_serializer.h
+++ b/src/socket_publisher/data_serializer.h
@@ -6,7 +6,7 @@
 #include <memory>
 
 #include <Eigen/Core>
-#include <sio_client.h>
+#include <sioclient/sio_client.h>
 #include <opencv2/core.hpp>
 
 namespace openvslam {

--- a/src/socket_publisher/socket_client.h
+++ b/src/socket_publisher/socket_client.h
@@ -3,7 +3,7 @@
 
 #include "openvslam/config.h"
 
-#include <sio_client.h>
+#include <sioclient/sio_client.h>
 
 namespace openvslam {
 class config;


### PR DESCRIPTION
This PR enables SLAM to load some parameters for the loop detector from yaml config.

2 parameters can be set.
* num_final_matches_thr (default: 40)
* min_continuity (default: 3)

To change these values, insert the following lines into config.yaml.
(The default values are used when nothing is given.)
```
LoopDetector.num_final_matches_threshold: 100
LoopDetector.min_continuity: 10
```