### PR TITLE
Migrate from Slack to Spectrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ If you would like to run visual SLAM with standard benchmarking datasets (e.g. K
 
 ## Community
 
-If you want to join our Slack community, please fill out the application form from the following site(s):
+If you want to join our Spectrum community, please join from the following link:
 
-- [http://bit.ly/openvslam](http://bit.ly/openvslam)
-- [http://bit.ly/openvslam-jp](http://bit.ly/openvslam-jp) (日本語: in Japanese)
+[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/openvslam)
 
 ## Currently working on
 


### PR DESCRIPTION
Replace the Slack's URL with Spectrum's one