### PR TITLE
Update Eigen source to use Gitlab

### DIFF
--- a/Dockerfile.desktop
+++ b/Dockerfile.desktop
@@ -59,10 +59,9 @@ ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPA
 ARG EIGEN3_VERSION=3.3.7
 WORKDIR /tmp
 RUN set -x && \
-  wget -q http://bitbucket.org/eigen/eigen/get/${EIGEN3_VERSION}.tar.bz2 && \
-  tar xf ${EIGEN3_VERSION}.tar.bz2 && \
-  rm -rf ${EIGEN3_VERSION}.tar.bz2 && \
-  mv eigen-eigen-* eigen-${EIGEN3_VERSION} && \
+  wget -q https://gitlab.com/libeigen/eigen/-/archive/${EIGEN3_VERSION}/eigen-${EIGEN3_VERSION}.tar.bz2 && \
+  tar xf eigen-${EIGEN3_VERSION}.tar.bz2 && \
+  rm -rf eigen-${EIGEN3_VERSION}.tar.bz2 && \
   cd eigen-${EIGEN3_VERSION} && \
   mkdir -p build && \
   cd build && \

--- a/Dockerfile.socket
+++ b/Dockerfile.socket
@@ -55,10 +55,9 @@ ENV LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:${LD_LIBRARY_PATH}
 ARG EIGEN3_VERSION=3.3.7
 WORKDIR /tmp
 RUN set -x && \
-  wget -q http://bitbucket.org/eigen/eigen/get/${EIGEN3_VERSION}.tar.bz2 && \
-  tar xf ${EIGEN3_VERSION}.tar.bz2 && \
-  rm -rf ${EIGEN3_VERSION}.tar.bz2 && \
-  mv eigen-eigen-* eigen-${EIGEN3_VERSION} && \
+  wget -q https://gitlab.com/libeigen/eigen/-/archive/${EIGEN3_VERSION}/eigen-${EIGEN3_VERSION}.tar.bz2 && \
+  tar xf eigen-${EIGEN3_VERSION}.tar.bz2 && \
+  rm -rf eigen-${EIGEN3_VERSION}.tar.bz2 && \
   cd eigen-${EIGEN3_VERSION} && \
   mkdir -p build && \
   cd build && \

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,10 +145,10 @@ Download and install Eigen from source.
 .. code-block:: bash
 
     cd /path/to/working/dir
-    wget -q http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2
-    tar xf 3.3.4.tar.bz2
-    rm -rf 3.3.4.tar.bz2
-    cd eigen-eigen-5a0156e40feb
+    wget -q https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2
+    tar xf eigen-3.3.7.tar.bz2
+    rm -rf eigen-3.3.7.tar.bz2
+    cd eigen-3.3.7
     mkdir -p build && cd build
     cmake \
         -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Bitbucket has stopped it's mercurial repository service as of August 26th, Gitlab works a suitable alternative with only minor changes.